### PR TITLE
feat(nanoclaw): live verbalizer + acceptance ratchet

### DIFF
--- a/HANDOFF_NANOCLAW.md
+++ b/HANDOFF_NANOCLAW.md
@@ -1,0 +1,137 @@
+# NanoClaw Handoff — Dispatch Continuation
+
+**Date:** 2026-05-10
+**Branch:** `claude/nanoclaw-feature` (main worktree, not a `.claude/worktrees/*` worktree)
+**Worktree path:** `C:/Users/james/OneDrive/Documents/Claude/Projects/AI Holding Company/ai-holding-company`
+**Head:** `63319e2`
+**Tests:** 28 passing (was 21 at prior handoff)
+**Companion doc:** `NANOCLAW_TEST_REPORT.md` at repo root — full system overview, packet examples, file map
+
+---
+
+## What this branch does
+
+Brings the persona conversational layer from "shadow-only, deterministic answers" to "production-ready Ollama-backed live answers, gated by an explicit acceptance ratchet". Live model output never reaches the owner unless it passes `verify_verbalizer_output()`. On any failure the deterministic fallback answers. Per-persona config flag controls promotion; no auto-promotion.
+
+R1 (Ollama only, no cloud APIs) is preserved. No new dependencies. Stdlib `urllib` only.
+
+---
+
+## Commits on this branch (latest first)
+
+| Commit | Subject |
+|---|---|
+| `63319e2` | feat: nanoclaw acceptance gate config + nanoclaw_status CLI |
+| `349ecce` | feat: gate nanoclaw_live behind config mode with verifier fallback |
+| `66dfc08` | feat: add nanoclaw_live verbalizer that calls local Ollama |
+| `1d8d3e1` | fix: drop urgency framing when chief-of-staff lead evidence is GREEN |
+| `9b047c0` | (prior handoff state — shadow pipeline complete) |
+
+Run `git log 9b047c0..HEAD --stat` for the full diff scope.
+
+---
+
+## Files touched
+
+| File | Role on this branch |
+|---|---|
+| `scripts/persona_verbalizer.py` | Added `nanoclaw_live_verbalize()`, `_effective_nanoclaw_mode()`, `_append_live_log()`. Extended `run_verbalizers()` with live-mode branch + verifier gate + fallback. GREEN guard in `_chief_status()`. |
+| `scripts/persona_router.py` | `answer_persona()` accepts new optional `full_config` kwarg and passes it to `run_verbalizers`. |
+| `scripts/tool_router.py` | `persona_chat` forwards `full_config=config`. New `nanoclaw_status` subcommand. |
+| `scripts/nanoclaw_status.py` | New module — reads live log, computes per-persona accept rate and `meets_gate`. |
+| `config/projects.yaml` | New `conversation.nanoclaw.promotion` (window, min_accept_rate), `personas` map (all `shadow`), `live_log_path`. |
+| `tests/test_persona_router.py` | +4 tests (GREEN guard, live success, live fallback on empty, live unreachable). |
+| `tests/test_nanoclaw_status.py` | New file — 3 tests (accept rate, gate condition, live log append). |
+
+---
+
+## How to run / verify
+
+```bash
+cd "C:/Users/james/OneDrive/Documents/Claude/Projects/AI Holding Company/ai-holding-company"
+
+# All NanoClaw-relevant tests
+python -m pytest tests/test_persona_router.py tests/test_tool_router_ask_company.py tests/test_nanoclaw_status.py -q
+# Expect: 28 passed
+
+# Smoke test the status CLI (will show zero traffic until live mode is enabled for at least one persona)
+python scripts/tool_router.py nanoclaw_status
+```
+
+---
+
+## Where we are in the plan
+
+The full plan is described in chat above and reproduced here for the cold reader.
+
+**Step 0 — Polish deterministic floor.** ✅ Done (`1d8d3e1`). GREEN lead evidence no longer triggers "I would focus there first".
+
+**Step 1 — `nanoclaw_live` provider.** ✅ Done (`66dfc08`). `nanoclaw_live_verbalize(packet, config)` POSTs the packet to `{phase2.ollama_base_url}/api/generate` with `{phase2.ollama_model}`. Single 20s timeout. No retries. No streaming. Returns `{"answer": "", ...}` on any failure so the verifier rejects it.
+
+**Step 2 — Wire the gate.** ✅ Done (`349ecce`). `run_verbalizers` resolves an effective mode per persona (`conversation.nanoclaw.personas[<persona>]` beats global `conversation.nanoclaw.mode`). If effective mode is `live`: call live, verify, use it if accepted, else use deterministic_fallback (tagged with `nanoclaw_live_rejected_reason`). Shadow inbox/outbox plumbing unchanged.
+
+**Step 3 — Acceptance gate config + status CLI.** ✅ Done (`63319e2`). Per-attempt records appended to `state/nanoclaw_live_log.jsonl`. `nanoclaw_status` CLI prints per-persona accept rate over the last `window` records and a `meets_gate` flag (`window_size >= window AND accept_rate >= min_accept_rate`). No auto-promotion.
+
+**Step 4 — Run shadow at volume.** 🔜 Not code. Owner uses Telegram normally; eventually flips one persona to `live` and watches `nanoclaw_status` until `meets_gate: true` for Chief of Staff.
+
+**Step 5 — Promote Chief of Staff to live.** 🔜 Config flip only:
+```yaml
+conversation:
+  nanoclaw:
+    personas:
+      chief-of-staff: "live"
+```
+Reversible — flip back to `shadow` instantly if accept rate dips.
+
+**Step 6 — Promote remaining personas one at a time.** 🔜 Order: Growth Lead → Editorial Lead → Engineering/Ops → Support Lead → Quant Ops → Risk Officer (last, because its outputs carry block/objection language).
+
+**Step 7 — Tighten the verifier.** 🔜 Code work. `verify_verbalizer_output()` currently rejects on empty answer or non-empty `unsupported_claims`. Once real model traffic accumulates, harden it: detect invented numbers, invented persona names, invented approvals, hallucinated dates. The verifier is the system's main quality lever post-live.
+
+**Step 8 — Retire shadow as a config option.** 🔜 Drop the `shadow` branch from `run_verbalizers` once all 8 personas have lived in `live` for a quarter. Shadow inbox/outbox logs remain as the audit trail.
+
+---
+
+## What dispatch should do next (priority order)
+
+1. **Open a PR** for this branch when ready. Suggested title: `feat(nanoclaw): live verbalizer + acceptance ratchet`. Body should reference `NANOCLAW_TEST_REPORT.md` for the system overview and this handoff for the change-set.
+
+2. **Verify Ollama is reachable on the host** that runs the Telegram bridge:
+   ```bash
+   curl -s http://127.0.0.1:11434/api/tags | head -c 200
+   ```
+   If empty or refused, Step 4 cannot start.
+
+3. **Skip ahead to Step 7 (verifier tightening) if owner wants more confidence before promoting any persona.** Concrete starter checks to add to `verify_verbalizer_output()`:
+   - Reject answers containing numbers that do not appear (textually or as numerals) anywhere in the truth packet.
+   - Reject answers containing persona slugs other than `packet["persona"]` (prevents one persona impersonating another).
+   - Reject answers longer than ~600 characters (current personas should be terse).
+   - All new rejection paths must be tested with both accept and reject cases.
+
+4. **Do not edit Step 5/6 prematurely.** Promotion is a single YAML edit; no code change needed. The plan deliberately keeps it that way.
+
+---
+
+## Hard constraints (from CLAUDE.md, do not violate)
+
+- **R1: Ollama only.** No cloud inference. `nanoclaw_live_verbalize` already obeys this — do not add OpenAI/Anthropic adapters.
+- **R11: No OpenClaw.** Telegram bridge is the sole automation interface.
+- **shell=False** on every subprocess call. None added on this branch; do not add any.
+- **No overengineering.** Do not introduce a "provider registry" or abstract base class to support hypothetical future models. One provider, one HTTP call.
+- **Code Review Gate.** Every block of work passes Codex review before the next block starts. This branch's 4 commits are individually small and reviewable.
+
+---
+
+## Known noise to ignore
+
+- Submodules `finance_web_page` and `mt5-agentic-desk` show pointer drift in `git status`. Memory note `project_property_promotion.md` says these are unpromoted properties; their drift is not a blocker on this branch.
+- The local main worktree's `git status -u` also lists many `.claude/worktrees/*/` and `.gstack/`, `projects/` untracked directories. Ignore — these are sibling worktrees and tooling state, not work artifacts.
+
+---
+
+## One non-obvious thing the next agent should know
+
+`run_verbalizers` takes BOTH `config=` (the `conversation.*` slice) and `full_config=` (the whole `projects.yaml` dict). The split exists because `nanoclaw_live_verbalize` needs `phase2.ollama_model` and `phase2.ollama_base_url`, which sit outside the conversation slice. `answer_persona` forwards both. `tool_router.py:persona_chat` passes them as `conversation_config=config.get("conversation", {})` and `full_config=config`. If you write a new caller, do the same.
+
+---
+
+*Written 2026-05-10 by Claude (sonnet 4.6 session) after committing `63319e2`. End of handoff.*

--- a/HANDOFF_NANOCLAW.md
+++ b/HANDOFF_NANOCLAW.md
@@ -3,7 +3,8 @@
 **Date:** 2026-05-10
 **Branch:** `claude/nanoclaw-feature` (main worktree, not a `.claude/worktrees/*` worktree)
 **Worktree path:** `C:/Users/james/OneDrive/Documents/Claude/Projects/AI Holding Company/ai-holding-company`
-**Head:** `63319e2`
+**Head:** `66cccdf`
+**PR:** [mangandajmz/ai-holding-company#10](https://github.com/mangandajmz/ai-holding-company/pull/10) — open, awaiting review
 **Tests:** 28 passing (was 21 at prior handoff)
 **Companion doc:** `NANOCLAW_TEST_REPORT.md` at repo root — full system overview, packet examples, file map
 
@@ -93,7 +94,7 @@ Reversible — flip back to `shadow` instantly if accept rate dips.
 
 ## What dispatch should do next (priority order)
 
-1. **Open a PR** for this branch when ready. Suggested title: `feat(nanoclaw): live verbalizer + acceptance ratchet`. Body should reference `NANOCLAW_TEST_REPORT.md` for the system overview and this handoff for the change-set.
+1. **Watch PR [#10](https://github.com/mangandajmz/ai-holding-company/pull/10) through review and merge.** Address review feedback on this branch; do not rebase or force-push unless the reviewer asks. After merge, delete the remote branch and update the head reference in this handoff if any follow-up work continues.
 
 2. **Verify Ollama is reachable on the host** that runs the Telegram bridge:
    ```bash
@@ -134,4 +135,4 @@ Reversible — flip back to `shadow` instantly if accept rate dips.
 
 ---
 
-*Written 2026-05-10 by Claude (sonnet 4.6 session) after committing `63319e2`. End of handoff.*
+*Written 2026-05-10 by Claude after PR #10 opened (head `66cccdf`). End of handoff.*

--- a/OVERNIGHT_CODEX_REPORT.md
+++ b/OVERNIGHT_CODEX_REPORT.md
@@ -1,0 +1,353 @@
+# Overnight Codex Report
+
+Date: 2026-05-09
+
+## Operating Rules Followed
+
+- Stayed inside the project folder.
+- Did not read or expose `.env`, credentials, private keys, tokens, or payment
+  details.
+- Did not delete files or run destructive commands.
+- Did not push, deploy, alter cloud/server/Docker/firewall/SSH/CI settings, or
+  contact external services.
+- Used safe local inspection and local tests only.
+
+## Running Changelog
+
+- Created `docs/agent-manned-saas-operating-model-v1.md` to define the
+  future-state agent-manned company model.
+- Updated `docs/agent-manned-saas-operating-model-v1.md` so communication is
+  natural by default and structured underneath.
+- Created `docs/agent-manned-saas-implementation-plan.md` with phased
+  milestones, gates, and rollout sequence.
+- Started implementation pass by inspecting first-party project structure,
+  current tests, and existing operating docs.
+- Created Phase 1 contract docs under `docs/agents/`,
+  `docs/communication/`, and `docs/skills/README.md`.
+- Updated `docs/STRUCTURE_MAP.md`, `docs/AGENT_ROLE_MODEL.md`, and
+  `docs/DAILY_OPERATING_SYSTEM.md` to reference the agent-manned contract
+  layer.
+- Created initial decision records for the operating-room model and agent
+  authority boundaries.
+- Added Phase 2 local truth spine:
+  - `scripts/org_truth_retriever.py`
+  - `scripts/chief_of_staff.py`
+  - `scripts/tool_router.py ask_company`
+- Added first safe staffed-loop runtime:
+  - `scripts/skill_risk_aggregate_daily.py`
+  - `scripts/tool_router.py risk_aggregate_daily`
+  - generated `reports/skills/risk-aggregate-daily/latest.*`
+- Added second P0 guardrail runtime:
+  - `scripts/skill_data_quality_daily.py`
+  - `scripts/tool_router.py data_quality_daily`
+  - generated `reports/skills/data-quality-daily/latest.*`
+- Extended `scripts/org_truth_retriever.py` and `scripts/chief_of_staff.py` so
+  Chief of Staff trading answers can use
+  `reports/skills/data-quality-daily/latest.json` as stored org truth.
+- Updated `README_TELEGRAM_BRIDGE.md` with the new agent-manned local commands.
+- Updated `ask_company` so conversational text is the default and structured
+  JSON is available with `--json`.
+- Added tests for truth retrieval, Chief of Staff answers, and CLI wiring.
+- Created nine skill contract docs under `docs/skills/`:
+  `risk-aggregate-daily`, `backtest-review`, `data-quality-daily`,
+  `content-brief-to-draft`, `analytics-weekly`, `portfolio-retro-weekly`,
+  `support-triage`, `pre-deploy-checklist`, and `broker-reconcile`.
+- Added third P0/P1-adjacent trading guardrail runtime:
+  - `scripts/skill_backtest_review.py`
+  - `scripts/tool_router.py backtest_review`
+  - generated `reports/skills/backtest-review/latest.*`
+- Connected backtest-review skill output back into the Chief of Staff truth
+  bundle so forward-test and strategy questions cite the stored guardrail
+  artifact.
+- Updated `docs/skills/backtest-review.md` and `README_TELEGRAM_BRIDGE.md`
+  with the local runtime command.
+- Added first website-side P0 shadow runtime:
+  - `scripts/skill_support_triage.py`
+  - `scripts/tool_router.py support_triage`
+  - generated `reports/skills/support-triage/latest.*`
+- Connected support-triage skill output back into the Chief of Staff truth
+  bundle so support/customer/ticket questions cite stored truth.
+- Updated `docs/skills/support-triage.md` and `README_TELEGRAM_BRIDGE.md`
+  with the local runtime command and current missing-inbox boundary.
+- Added Telegram bridge slash-command access for the agent-manned surfaces:
+  - `/ask_company <question>`
+  - `/risk_aggregate_daily`
+  - `/data_quality_daily`
+  - `/backtest_review`
+  - `/support_triage`
+- Classified those new Telegram commands as `view_status` actions so they stay
+  safe/read-only from the bridge authority model.
+- Added weekly holdco retro runtime:
+  - `scripts/skill_portfolio_retro_weekly.py`
+  - `scripts/tool_router.py portfolio_retro_weekly`
+  - `/portfolio_retro_weekly` in Telegram
+  - generated `reports/skills/portfolio-retro-weekly/latest.*`
+
+## Current Focus
+
+Implement the safest high-value parts of the plan:
+
+1. Phase 1 contracts for agents, communication, and skill surfaces.
+2. Phase 2 truth-grounded Chief of Staff spine if it can be done safely with
+   local files and tests.
+
+## Test / Build Log
+
+- RED: `python -m pytest tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  failed because the new modules did not exist yet.
+- GREEN: `python -m pytest tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 6 tests.
+- RED: `python -m pytest tests\test_tool_router_ask_company.py -q` failed because
+  `ask_company` was not yet wired into `tool_router.py`.
+- GREEN: `python -m pytest tests\test_tool_router_ask_company.py tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 7 tests.
+- Smoke: `python scripts\tool_router.py ask_company --question "What needs me today?"`
+  returned a truth-grounded local answer from current reports and approval
+  state.
+- Full sweep: `python -m pytest -q` ran 369 tests total and ended with
+  361 passed, 2 skipped, 6 failed. The failures are in nested
+  `mt5-agentic-desk` tests that assume the working directory is the nested MT5
+  repo and cannot find `main.py`, `README.md`, or nested `scripts/*.ps1` from
+  the parent repo cwd.
+- Parent suite: `python -m pytest tests -q` passed: 199 tests.
+- RED/GREEN: added evidence-on-request behavior for the Chief of Staff. First
+  `python -m pytest tests\test_chief_of_staff.py -q` failed as expected, then
+  `python -m pytest tests\test_chief_of_staff.py tests\test_org_truth_retriever.py tests\test_tool_router_ask_company.py -q`
+  passed: 8 tests.
+- Parent suite after evidence-on-request change: `python -m pytest tests -q`
+  passed: 200 tests.
+- RED/GREEN: added `risk_aggregate_daily` skill wrapper. Initial tests failed
+  because the module/router command did not exist; after implementation,
+  `python -m pytest tests\test_tool_router_ask_company.py tests\test_skill_risk_aggregate_daily.py tests\test_chief_of_staff.py tests\test_org_truth_retriever.py -q`
+  passed: 10 tests.
+- Smoke: `python scripts\tool_router.py risk_aggregate_daily` generated a
+  current local brief and sidecar under
+  `reports/skills/risk-aggregate-daily/`.
+- Parent suite after `risk_aggregate_daily`: `python -m pytest tests -q`
+  passed: 202 tests.
+- RED/GREEN: added `data_quality_daily` guardrail wrapper. Initial tests failed
+  because the module/router command did not exist; after implementation,
+  `python -m pytest tests\test_tool_router_ask_company.py tests\test_skill_data_quality_daily.py tests\test_skill_risk_aggregate_daily.py tests\test_chief_of_staff.py tests\test_org_truth_retriever.py -q`
+  passed: 13 tests.
+- Smoke: `python scripts\tool_router.py data_quality_daily --as-of 2026-05-09`
+  generated a current local guardrail report under
+  `reports/skills/data-quality-daily/`.
+- Parent suite after `data_quality_daily`: `python -m pytest tests -q`
+  passed: 205 tests.
+- RED/GREEN: added skill-output retrieval tests. Initial tests failed because
+  data-quality skill output was not part of the truth bundle; after
+  implementation,
+  `python -m pytest tests\test_org_truth_retriever.py tests\test_chief_of_staff.py tests\test_tool_router_ask_company.py tests\test_skill_data_quality_daily.py tests\test_skill_risk_aggregate_daily.py -q`
+  passed: 15 tests.
+- Smoke: `python scripts\tool_router.py ask_company --question "Why is trading yellow? Show evidence"`
+  now includes `reports/skills/data-quality-daily/latest.json` as a source.
+- Parent suite after skill-output retrieval: `python -m pytest tests -q`
+  passed: 207 tests.
+- Compile check: `python -m py_compile scripts\org_truth_retriever.py scripts\chief_of_staff.py scripts\skill_risk_aggregate_daily.py scripts\skill_data_quality_daily.py scripts\tool_router.py`
+  passed.
+- Final parent suite: `python -m pytest tests -q` passed: 207 tests.
+- RED/GREEN: changed `ask_company` to conversational default. Initial tests
+  failed because rendering and `--json` support did not exist; after
+  implementation, `python -m pytest tests\test_chief_of_staff.py tests\test_tool_router_ask_company.py -q`
+  passed: 10 tests.
+- Compile check after conversational default:
+  `python -m py_compile scripts\chief_of_staff.py scripts\tool_router.py`
+  passed.
+- Parent suite after conversational default: `python -m pytest tests -q`
+  passed: 209 tests.
+- Smoke: `python scripts\tool_router.py ask_company --question "What needs me today?"`
+  now prints conversational text by default.
+- Smoke: `python scripts\tool_router.py ask_company --question "What needs me today?" --json`
+  still returns structured JSON for tooling.
+- RED/GREEN: added `backtest_review` guardrail wrapper. Initial tests failed
+  because the module/router command did not exist; after implementation,
+  `python -m pytest tests\test_skill_backtest_review.py tests\test_tool_router_ask_company.py -q`
+  passed: 8 tests.
+- RED/GREEN: connected backtest-review output to the Chief of Staff truth
+  bundle. Initial tests failed because `TruthBundle` did not expose the
+  backtest review and forward-test questions still fell through to generic
+  trading status; after implementation,
+  `python -m pytest tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 12 tests.
+- Smoke: `python scripts\tool_router.py backtest_review` generated a current
+  local guardrail report under `reports/skills/backtest-review/` and blocked
+  forward-test based on current MT5 evidence: 8 selected, 0 approved, 0
+  out-of-sample, 0 walk-forward.
+- Smoke: `python scripts\tool_router.py ask_company --question "Can any strategy move to forward-test? Show evidence"`
+  answered from `reports/skills/backtest-review/latest.json` and cited
+  sources.
+- Focused check after backtest-review:
+  `python -m pytest tests\test_skill_backtest_review.py tests\test_tool_router_ask_company.py tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 20 tests.
+- Compile check after backtest-review:
+  `python -m py_compile scripts\skill_backtest_review.py scripts\org_truth_retriever.py scripts\chief_of_staff.py scripts\tool_router.py`
+  passed.
+- Parent suite after backtest-review: `python -m pytest tests -q` passed: 215
+  tests.
+- RED/GREEN: added `support_triage` shadow runtime. Initial tests failed
+  because the module/router command did not exist; after implementation,
+  `python -m pytest tests\test_skill_support_triage.py tests\test_tool_router_ask_company.py -q`
+  passed: 8 tests.
+- RED/GREEN: connected support-triage output to the Chief of Staff truth
+  bundle. Initial tests failed because `TruthBundle` did not expose support
+  triage and support questions fell through to generic company needs; after
+  implementation,
+  `python -m pytest tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 14 tests.
+- Smoke: `python scripts\tool_router.py support_triage` generated a current
+  local shadow report under `reports/skills/support-triage/` and correctly
+  blocked because no `state/support_tickets.json` source exists yet.
+- Smoke: `python scripts\tool_router.py ask_company --question "What is happening in support? Show evidence"`
+  answered from `reports/skills/support-triage/latest.json` and cited sources.
+- Focused check after support-triage:
+  `python -m pytest tests\test_skill_support_triage.py tests\test_tool_router_ask_company.py tests\test_org_truth_retriever.py tests\test_chief_of_staff.py -q`
+  passed: 22 tests.
+- Compile check after support-triage:
+  `python -m py_compile scripts\skill_support_triage.py scripts\org_truth_retriever.py scripts\chief_of_staff.py scripts\tool_router.py`
+  passed.
+- Parent suite after support-triage: `python -m pytest tests -q` passed: 220
+  tests.
+- RED/GREEN: added Telegram bridge routing for the new agent-manned commands.
+  Initial `python -m pytest tests\test_aiogram_bridge.py -q` failed because
+  the bridge did not classify or route `/ask_company`, `/risk_aggregate_daily`,
+  `/data_quality_daily`, `/backtest_review`, or `/support_triage`; after
+  implementation, it passed: 38 tests.
+- Focused bridge/truth check:
+  `python -m pytest tests\test_aiogram_bridge.py tests\test_tool_router_ask_company.py tests\test_chief_of_staff.py tests\test_org_truth_retriever.py -q`
+  passed: 58 tests.
+- Compile check after Telegram bridge routing:
+  `python -m py_compile scripts\aiogram_bridge.py scripts\tool_router.py scripts\chief_of_staff.py scripts\org_truth_retriever.py`
+  passed.
+- Parent suite after Telegram bridge routing: `python -m pytest tests -q`
+  passed: 223 tests.
+- RED/GREEN: added `portfolio_retro_weekly` skill wrapper and Telegram route.
+  Initial focused tests failed because the module/router/bridge command did not
+  exist; after implementation,
+  `python -m pytest tests\test_skill_portfolio_retro_weekly.py tests\test_tool_router_ask_company.py tests\test_aiogram_bridge.py -q`
+  passed: 48 tests.
+- Smoke: `python scripts\tool_router.py portfolio_retro_weekly` generated a
+  current retro under `reports/skills/portfolio-retro-weekly/`. It is BLOCKED
+  from stored truth: backtest-review blocked, support-triage blocked, and the
+  risk aggregate is RED.
+- Focused check after portfolio retro:
+  `python -m pytest tests\test_skill_portfolio_retro_weekly.py tests\test_tool_router_ask_company.py tests\test_aiogram_bridge.py tests\test_skill_backtest_review.py tests\test_skill_support_triage.py -q`
+  passed: 53 tests.
+- Compile check after portfolio retro:
+  `python -m py_compile scripts\skill_portfolio_retro_weekly.py scripts\tool_router.py scripts\aiogram_bridge.py`
+  passed.
+- Parent suite after portfolio retro: `python -m pytest tests -q` passed: 227
+  tests.
+
+## Issues / Blocks
+
+- Existing worktree had unrelated dirty/untracked items before this overnight
+  implementation pass. These were left untouched.
+- Broad parent-level pytest discovery includes nested `mt5-agentic-desk/tests`
+  whose path assumptions fail from the parent cwd. I did not modify those tests
+  overnight because the failure is pre-existing discovery/cwd behavior and not
+  required for the Chief of Staff spine.
+
+## Completed
+
+- Defined the agent-manned company future state and implementation milestones.
+- Added first-wave agent role contracts.
+- Added natural communication, truth-grounding, and handoff rules.
+- Added nine skill contracts from the retrofit plan.
+- Added decision records for operating-room and authority boundaries.
+- Implemented the local Chief of Staff `ask_company` spine.
+- Implemented `risk_aggregate_daily` skill artifact generation.
+- Implemented `data_quality_daily` guardrail artifact generation.
+- Connected data-quality skill output back into Chief of Staff retrieval.
+- Implemented `backtest_review` guardrail artifact generation.
+- Connected backtest-review skill output back into Chief of Staff answers for
+  backtest, strategy, and forward-test questions.
+- Implemented `support_triage` shadow artifact generation.
+- Connected support-triage skill output back into Chief of Staff answers for
+  support, ticket, and customer questions.
+- Exposed the working agent-manned commands through the existing Telegram
+  bridge without touching protected property folders.
+- Implemented `portfolio_retro_weekly` as a skill-shaped holdco artifact that
+  aggregates the other skill outputs and approval state.
+
+## Files Changed By This Pass
+
+- `OVERNIGHT_CODEX_REPORT.md`
+- `README_TELEGRAM_BRIDGE.md`
+- `docs/AGENT_ROLE_MODEL.md`
+- `docs/DAILY_OPERATING_SYSTEM.md`
+- `docs/STRUCTURE_MAP.md`
+- `docs/agent-manned-saas-operating-model-v1.md`
+- `docs/agent-manned-saas-implementation-plan.md`
+- `docs/retrofit-plan-analysis.md`
+- `docs/agents/*`
+- `docs/communication/*`
+- `docs/decisions/*`
+- `docs/skills/*`
+- `reports/chief_of_staff/README.md`
+- `reports/skills/risk-aggregate-daily/*`
+- `reports/skills/data-quality-daily/*`
+- `reports/skills/backtest-review/*`
+- `reports/skills/support-triage/*`
+- `reports/skills/portfolio-retro-weekly/*`
+- `scripts/chief_of_staff.py`
+- `scripts/aiogram_bridge.py`
+- `scripts/org_truth_retriever.py`
+- `scripts/skill_backtest_review.py`
+- `scripts/skill_portfolio_retro_weekly.py`
+- `scripts/skill_risk_aggregate_daily.py`
+- `scripts/skill_data_quality_daily.py`
+- `scripts/skill_support_triage.py`
+- `scripts/tool_router.py`
+- `tests/test_chief_of_staff.py`
+- `tests/test_aiogram_bridge.py`
+- `tests/test_org_truth_retriever.py`
+- `tests/test_skill_backtest_review.py`
+- `tests/test_skill_portfolio_retro_weekly.py`
+- `tests/test_skill_data_quality_daily.py`
+- `tests/test_skill_risk_aggregate_daily.py`
+- `tests/test_skill_support_triage.py`
+- `tests/test_tool_router_ask_company.py`
+
+## Tasks Needing Approval
+
+- None were required overnight.
+- Slack setup still needs owner approval before any signup, workspace change,
+  app install, token creation, or external API access.
+- Support triage needs owner approval before connecting Gmail, Slack, Helpdesk,
+  or any real customer inbox. The current runtime only reads local
+  `state/support_tickets.json` if it exists.
+- Any production deployment, GitHub push, server/cloud/Docker/SSH/CI change,
+  or credential work still needs approval.
+
+## Recommended Next Steps
+
+1. Review `docs/agent-manned-saas-implementation-plan.md` and the new
+   `docs/agents/` contracts.
+2. Try:
+
+   ```powershell
+   python scripts/tool_router.py ask_company --question "What needs me today?"
+   python scripts/tool_router.py ask_company --question "Why is trading yellow? Show evidence"
+   python scripts/tool_router.py risk_aggregate_daily
+   python scripts/tool_router.py data_quality_daily
+   python scripts/tool_router.py backtest_review
+   python scripts/tool_router.py ask_company --question "Can any strategy move to forward-test? Show evidence"
+   python scripts/tool_router.py support_triage
+   python scripts/tool_router.py ask_company --question "What is happening in support? Show evidence"
+   ```
+
+   Telegram equivalents are now:
+
+   ```text
+   /ask_company What needs me today?
+   /risk_aggregate_daily
+   /data_quality_daily
+   /backtest_review
+   /support_triage
+   /portfolio_retro_weekly
+   ```
+
+3. Decide whether the next surface should be Telegram aliases or Slack operating
+   room design.
+4. Build the next P0 runtime: `backtest-review`, using MT5 evidence artifacts
+   without moving MT5 logic into the parent repo.

--- a/README_TELEGRAM_BRIDGE.md
+++ b/README_TELEGRAM_BRIDGE.md
@@ -142,3 +142,71 @@ python scripts/aiogram_bridge.py --simulate-text "/assign <board_approval_id>"
 python scripts/aiogram_bridge.py --simulate-text "/start <board_approval_id>"
 python scripts/aiogram_bridge.py --simulate-text "/done <board_approval_id> Completed remediation and validation notes"
 ```
+
+## 11) Agent-manned local commands
+
+These local CLI surfaces prove grounded natural communication and skill
+artifacts before any broader operating-room change. The same surfaces are also
+available through Telegram slash commands.
+
+Ask the Chief of Staff a natural question:
+
+```powershell
+python scripts/tool_router.py ask_company --question "What needs me today?"
+```
+
+Return structured JSON for tooling:
+
+```powershell
+python scripts/tool_router.py ask_company --question "What needs me today?" --json
+```
+
+Ask for evidence explicitly:
+
+```powershell
+python scripts/tool_router.py ask_company --question "Why is trading yellow? Show evidence"
+```
+
+Generate the daily holdco risk aggregate artifact:
+
+```powershell
+python scripts/tool_router.py risk_aggregate_daily
+```
+
+Generate the trading data-quality guardrail artifact:
+
+```powershell
+python scripts/tool_router.py data_quality_daily
+```
+
+Generate the trading backtest-review guardrail artifact:
+
+```powershell
+python scripts/tool_router.py backtest_review
+```
+
+Generate the website support-triage shadow artifact:
+
+```powershell
+python scripts/tool_router.py support_triage
+```
+
+Generate the weekly portfolio retro artifact:
+
+```powershell
+python scripts/tool_router.py portfolio_retro_weekly
+```
+
+Telegram equivalents:
+
+```text
+/ask_company What needs me today?
+/risk_aggregate_daily
+/data_quality_daily
+/backtest_review
+/support_triage
+/portfolio_retro_weekly
+```
+
+The owner-facing answer should stay conversational. Structured truth is stored
+under `reports/skills/`, `state/`, `memory/`, and `docs/decisions/`.

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -32,6 +32,13 @@ memory:
   ollama_base_url: "http://127.0.0.1:11434"
   embedding_model: "nomic-embed-text"
 
+conversation:
+  provider: "deterministic_fallback"
+  nanoclaw:
+    mode: "shadow"
+    shadow_inbox_path: "state/nanoclaw_shadow_inbox.jsonl"
+    shadow_outbox_path: "state/nanoclaw_shadow_outbox.jsonl"
+
 trading_bots:
   - id: "mt5_desk"
     name: "MT5 Agentic Trading Desk"

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -192,13 +192,53 @@ property_charters:
       r12_formula_version: website_v1
   mt5_forex_bot:
     charter:
-      version: v0-stub
-      wedge: "Forex momentum strategy on majors, monitored by AI Holding Co"
-      property_type: trading_bot
-      phase: maintain
-      value_readiness_date: 2026-01-01
+      version: v1
+      wedge: "Private MT5 trading lab for backtesting, demo/paper decision tracking, and process evidence that feeds low-risk FreeTraderHub tools. Hard rule: productize the process, not the trades."
+      property_type: private_trading_lab
+      phase: evidence_build
+      value_readiness_date: 2026-06-03
       internal_rate_usd_hr: 75
-      r12_formula_version: trading_bot_v1
+      r12_formula_version: trading_lab_v1
+      repo_path_current: "C:/Users/james/OneDrive/Documents/Claude/Projects/AI Holding Company/ai-holding-company/mt5-agentic-desk"
+      repo_path_target: "C:/Users/james/OneDrive/Documents/Claude/Projects/AI Holding Company/ai-holding-company/projects/mt5-agentic-desk"
+      business_plan_file: "docs/business-and-execution-plan-2026-05-04.md"
+      evidence_checklist_file: "docs/evidence-build-checklist-2026-05-04.md"
+    tracking:
+      trading_bot_id: mt5_desk
+      public_property_id: freetraderhub
+    promotion:
+      promoted: false
+      business_case_defined: true
+      target_product_defined: true
+      feasibility_validated: false
+      roi_case_defined: false
+      monetization_boundary_defined: true
+      hard_rule: "Productize the process, not the trades."
+      public_monetization_allowed:
+        - process_tools
+        - rule_calculators
+        - journaling_templates
+        - education
+        - disclosed_affiliate_referrals
+      public_monetization_forbidden:
+        - paid_signals
+        - copy_trading
+        - managed_accounts
+        - ai_profit_claims
+      autonomy_gate:
+        min_demo_paper_decisions: 100
+        include_no_trade_decisions: true
+        min_runtime_log_days_without_unresolved_safety_failures: 30
+        requires_out_of_sample_evidence: true
+        requires_walk_forward_evidence: true
+      metrics_defined:
+        - demo_paper_decisions_logged
+        - no_trade_decisions_logged
+        - strategy_cohorts_tracked
+        - unresolved_safety_failures
+        - tool_ideas_generated
+        - public_features_shipped_from_private_pain
+      notes: "MT5 Agentic Desk is a private evidence engine. FreeTraderHub may monetize safer process outputs only. The repo should move under projects/ after the active workspace is no longer rooted inside the folder."
   polymarket_bot:
     charter:
       version: v0-stub

--- a/config/projects.yaml
+++ b/config/projects.yaml
@@ -38,6 +38,19 @@ conversation:
     mode: "shadow"
     shadow_inbox_path: "state/nanoclaw_shadow_inbox.jsonl"
     shadow_outbox_path: "state/nanoclaw_shadow_outbox.jsonl"
+    live_log_path: "state/nanoclaw_live_log.jsonl"
+    promotion:
+      window: 50
+      min_accept_rate: 0.80
+    personas:
+      chief-of-staff: "shadow"
+      risk-officer: "shadow"
+      quant-ops: "shadow"
+      growth-lead: "shadow"
+      editorial-lead: "shadow"
+      engineering-ops: "shadow"
+      support-lead: "shadow"
+      finance-admin: "shadow"
 
 trading_bots:
   - id: "mt5_desk"

--- a/docs/AGENT_ROLE_MODEL.md
+++ b/docs/AGENT_ROLE_MODEL.md
@@ -3,6 +3,11 @@
 Keep the active role model small. These roles describe responsibilities and
 limits; they do not require separate runtime agents yet.
 
+For the agent-manned SaaS future state, first-wave staff contracts now live in
+`docs/agents/`. Those contracts describe which roles can later become persistent
+agent employees once they own a recurring business function. This table remains
+the compact role baseline for current repo work.
+
 | Role | Purpose | Inputs | Outputs | Approval limits | Allowed files |
 |---|---|---|---|---|---|
 | CEO Strategist | Convert evidence into CEO decisions. | Reports, scorecards, board items. | CEO summary, priorities, approval requests. | Cannot approve risky actions for the CEO. | `reports/`, `state/`, `docs/` |
@@ -14,3 +19,9 @@ limits; they do not require separate runtime agents yet.
 | Commercial Analyst | Score initiatives and business cases. | Costs, traffic, revenue, effort. | ROI estimate, go/no-go recommendation. | Cannot commit spend or business obligations. | `reports/`, `docs/`, `config/` |
 | Risk Manager | Stress-test approvals and risky actions. | Board items, plans, scorecards. | Objections, risk notes, mitigation checks. | Cannot override CEO. | `reports/`, `docs/`, `state/` |
 | Operations Coordinator | Keep reports, routines, and owner review moving. | Schedules, state, report outputs. | Daily/weekly operating notes. | Cannot execute irreversible actions. | `reports/`, `state/`, `docs/` |
+
+## Communication Rule
+
+Roles should communicate naturally to the owner and store structured evidence
+underneath. See `docs/communication/natural-agent-communication.md` and
+`docs/communication/truth-grounding-rules.md`.

--- a/docs/DAILY_OPERATING_SYSTEM.md
+++ b/docs/DAILY_OPERATING_SYSTEM.md
@@ -10,6 +10,9 @@ would reduce friction.
 - Approval state: `state/board_approval_decisions.json`
 - Company memory: `memory/`
 - Agent and division prompts: `crews/`
+- Agent staff contracts: `docs/agents/`
+- Skill contracts: `docs/skills/`
+- Communication rules: `docs/communication/`
 - Runtime config and KPI targets: `config/`
 - Telegram bridge: `scripts/aiogram_bridge.py`
 - Command router: `scripts/tool_router.py`
@@ -105,6 +108,16 @@ would reduce friction.
    python scripts/tool_router.py log_direction --text "Your CEO direction here."
    ```
 
+9. Ask the company naturally once the Chief of Staff spine is wired.
+
+   ```powershell
+   python scripts/tool_router.py ask_company --question "What needs me today?"
+   ```
+
+   The expected behavior is conversational output grounded in `reports/`,
+   `state/`, `memory/`, and `docs/decisions/`, with source paths available for
+   consequential claims.
+
 ## Approval Rule
 
 Anything involving trading action, money, publishing, deployment, external
@@ -117,6 +130,8 @@ For the next phase, prefer improving clarity over adding machinery:
 
 - Do not add OpenClaw.
 - Do not add new agents unless one existing role cannot reasonably cover the work.
+- Do not make visible communication rigid by default; store structure
+  underneath and keep owner interaction natural.
 - Do not add trading execution.
 - Do not add automatic publishing.
 - Do not add credentials or secrets.

--- a/docs/STRUCTURE_MAP.md
+++ b/docs/STRUCTURE_MAP.md
@@ -17,6 +17,9 @@ equivalents unless the current layout starts slowing down daily CEO review.
 | Agent prompts/configs | `crews/`, `config/` | No separate prompt tree needed yet. |
 | Workflows/docs | root runbooks, `docs/` | New operator-facing docs live in `docs/`. |
 | Websites | `finance_web_page/`, `free-utility-tools/`, `free-traderhub-research-team/` | Website source remains protected by approval rules. |
+| Agent staff contracts | `docs/agents/` | First-wave role contracts for the agent-manned company. |
+| Skill contracts | `docs/skills/` | Repeatable operating workflows; runtime still uses existing rails. |
+| Communication rules | `docs/communication/` | Natural conversation on the surface, structured truth underneath. |
 
 ## Keep
 
@@ -31,10 +34,14 @@ equivalents unless the current layout starts slowing down daily CEO review.
 - Old OpenClaw references are deprecated and should not guide new work.
 - `reports/` is flat but functional. Archive only when it becomes hard to scan.
 - Website QA should be captured as simple checklists before adding more browser automation.
+- Agent contracts describe responsibilities before runtime. They do not require
+  separate runtime agents until a recurring business function is proven.
+- Natural agent communication is owner-facing. Structured records still belong
+  in `reports/`, `state/`, `memory/`, and `docs/decisions/`.
 
 ## Add Later Only If Needed
 
 - A physical `company_os/` folder.
-- Separate `agents/prompts/configs/skills` folders.
+- A separate runtime agent framework.
 - Report archiving scripts.
 - More agent roles or external chat surfaces.

--- a/docs/agent-manned-saas-implementation-plan.md
+++ b/docs/agent-manned-saas-implementation-plan.md
@@ -1,0 +1,506 @@
+# Agent-Manned SaaS Company Implementation Plan
+
+Date: 2026-05-09
+
+## Intent
+
+This plan turns the agent-manned SaaS operating model into an implementation
+sequence. The goal is to build a company that feels staffed by agents, not a
+larger collection of scripts.
+
+The implementation principle is:
+
+> Natural conversation on the surface, structured truth underneath, controlled
+> execution through approved rails.
+
+The first milestone is not full autonomy. The first milestone is a dependable
+operating rhythm where agents communicate naturally, reference company truth,
+leave durable records, and reduce the owner's cognitive load.
+
+## Success Definition
+
+The implementation is working when the owner can ask the company natural
+questions and receive grounded answers:
+
+- What needs me today?
+- Why is trading yellow?
+- What did Growth learn this week?
+- Are we ready to forward-test this strategy?
+- What are we blocked on?
+- What did we try before?
+
+The answer should feel conversational, but the system should be able to cite the
+stored truth behind it.
+
+## Non-Negotiables
+
+- Do not create a parallel agent platform before the operating loop is proven.
+- Do not make chat the source of truth.
+- Do not let agents invent company status, metrics, decisions, revenue, trades,
+  approvals, or customer facts.
+- Do not auto-execute trading, publishing, spend, credentials, business
+  commitments, legal/tax-sensitive work, or external communication.
+- Do not replace existing Telegram/CLI/report/state rails until the replacement
+  is demonstrably better.
+- Do not expose rigid status templates to the owner by default. Store structure
+  underneath; communicate naturally.
+
+## Architecture To Build Toward
+
+| Layer | Purpose | First implementation |
+|---|---|---|
+| Conversation | Natural CEO and agent communication | Chief of Staff chat/command, later Slack |
+| Truth retrieval | Ground answers in company records | Reports/state/memory/work-item retriever |
+| Agent staff | Own recurring business functions | Chief of Staff, Quant Ops, Risk, Growth, Editorial, Engineering/Ops |
+| Durable records | Preserve evidence, decisions, and outputs | `reports/`, `state/`, `memory/`, `docs/decisions/` |
+| Execution rails | Run approved actions safely | Existing scripts, approvals, Telegram, later Slack buttons |
+| Dashboard | Current company status | Later, after the first loops are trustworthy |
+
+## Rollout Overview
+
+| Phase | Timebox | Goal |
+|---|---|---|
+| 0. Decision Lock | 1-2 days | Decide surfaces, first agents, and truth rules |
+| 1. Contract Layer | Week 1 | Define roles, skills, channels, records, and handoffs |
+| 2. Chief of Staff Spine | Weeks 2-3 | Natural CEO interface grounded in stored truth |
+| 3. First Staffed Loops | Weeks 3-6 | Daily CEO brief, trading readiness, website growth |
+| 4. Operating Room | Weeks 5-7 | Slack or hybrid communication with durable records |
+| 5. Execution And Approvals | Weeks 6-9 | One-click approval flow and follow-through |
+| 6. Live Operating Rhythm | Weeks 8-12 | Move shadow loops to live where safe |
+| 7. Expansion | Post-90 days | Support, Finance/Admin, broker recon, dashboard depth |
+
+Phases can overlap, but each phase has a gate. If a gate fails, do not widen the
+system; fix the loop.
+
+## Phase 0: Decision Lock
+
+Timebox: 1-2 days.
+
+Purpose: remove ambiguity before building.
+
+Decisions to make:
+
+1. Operating room: Slack-first, Telegram-first, or hybrid.
+2. CEO interface: Slack DM/channel, Telegram, local CLI, dashboard chat, or a
+   staged combination.
+3. First agent identities: functional titles only or named staff personas.
+4. First business focus: FreeTraderHub only for websites, or all properties.
+5. Support source: defer until inbox exists, or choose a support intake now.
+6. Trading boundary: exact meaning of research, forward test, paper, and live.
+7. Memory rule: what must be written after decisions, blocks, and lessons.
+
+Deliverables:
+
+- Edit `docs/agent-manned-saas-operating-model-v1.md` with locked decisions.
+- Create `docs/decisions/0001-agent-operating-room.md`.
+- Create `docs/decisions/0002-agent-authority-boundaries.md`.
+
+Gate:
+
+- The owner can explain, in one minute, where agents talk, where truth lives,
+  what they can do, and what they must escalate.
+
+## Phase 1: Contract Layer
+
+Timebox: Week 1.
+
+Purpose: define the company before adding runtime.
+
+Files to create:
+
+- `docs/agents/README.md`
+- `docs/agents/chief-of-staff.md`
+- `docs/agents/quant-ops.md`
+- `docs/agents/risk-officer.md`
+- `docs/agents/growth-lead.md`
+- `docs/agents/editorial-lead.md`
+- `docs/agents/engineering-ops.md`
+- `docs/skills/README.md`
+- `docs/communication/natural-agent-communication.md`
+- `docs/communication/truth-grounding-rules.md`
+- `docs/communication/handoff-rules.md`
+
+Files to edit:
+
+- `docs/AGENT_ROLE_MODEL.md`
+- `docs/DAILY_OPERATING_SYSTEM.md`
+- `docs/STRUCTURE_MAP.md`
+- `README_TELEGRAM_BRIDGE.md`
+
+Key design:
+
+- Agent docs define job, cadence, inputs, outputs, authority, escalation, memory
+  obligations, and success metrics.
+- Communication docs define natural language style for CEO-facing answers.
+- Structured records are defined as sidecar state/report data, not as the
+  default visible message format.
+
+Gate:
+
+- Every first-wave agent has a clear business function and value metric.
+- The anti-theater test passes for every first-wave agent.
+- No runtime agents are added just because a role exists.
+
+## Phase 2: Chief of Staff Spine
+
+Timebox: Weeks 2-3.
+
+Purpose: create one natural owner-facing front door to the company.
+
+First behavior:
+
+- Owner asks natural questions.
+- Chief of Staff retrieves relevant reports, state, memory, approvals, and
+  decisions.
+- Chief of Staff answers conversationally.
+- Chief of Staff cites sources when asked or when the answer is consequential.
+- Unknown and stale information are called out plainly.
+
+Files to create:
+
+- `scripts/org_truth_retriever.py`
+- `scripts/chief_of_staff.py`
+- `tests/test_org_truth_retriever.py`
+- `tests/test_chief_of_staff.py`
+- `reports/chief_of_staff/README.md`
+
+Files to edit:
+
+- `scripts/tool_router.py`
+- `scripts/aiogram_bridge.py` only if Telegram is used for the first surface.
+
+Candidate command:
+
+```powershell
+python scripts/tool_router.py ask_company --question "What needs me today?"
+```
+
+Design constraints:
+
+- Retrieval must happen before factual answers.
+- Answers must classify facts as known, inferred, unknown, or stale internally.
+- Sources are available without making every normal answer feel like an audit.
+- No external network calls without explicit approval.
+
+Gate:
+
+- The owner can ask 10 common company questions and get useful, natural,
+  grounded answers.
+- The system refuses or qualifies answers when truth is missing.
+- The interaction feels better than reading raw reports.
+
+## Phase 3: First Staffed Loops
+
+Timebox: Weeks 3-6.
+
+Purpose: make the company feel staffed through three complete operating loops.
+
+### Loop 1: Daily CEO Brief
+
+Agents involved:
+
+- Chief of Staff
+- Risk Officer
+- Growth Lead
+- Quant Ops
+- Engineering/Ops
+
+Files to create or adapt:
+
+- `docs/skills/risk-aggregate-daily.md`
+- `scripts/skill_risk_aggregate_daily.py` or a thin alias over
+  `scripts/phase3_holding.py`
+- `reports/skills/risk-aggregate-daily/`
+
+Output:
+
+- Natural CEO-facing daily brief.
+- Structured sidecar with status, evidence, owner needs, and agent handoffs.
+
+Gate:
+
+- Owner can read the daily brief in under five minutes.
+- It contains only real issues, decisions, and useful context.
+- Every consequential claim links to retrievable truth.
+
+### Loop 2: Trading Readiness
+
+Agents involved:
+
+- Quant Ops
+- Quant Research Lead
+- Risk Officer
+- Chief of Staff
+
+Files to create or adapt:
+
+- `docs/skills/data-quality-daily.md`
+- `docs/skills/backtest-review.md`
+- `docs/skills/pre-deploy-checklist.md`
+- `scripts/skill_data_quality_daily.py`
+- `scripts/skill_backtest_review.py`
+- `reports/skills/data-quality-daily/`
+- `reports/skills/backtest-review/`
+
+Output:
+
+- Data-quality result before trading/research decisions.
+- Adversarial backtest review before forward-test.
+- Risk block or pass-for-owner-approval.
+
+Gate:
+
+- No strategy reaches forward test without data-quality and backtest review
+  artifacts.
+- Risk can block, but cannot approve.
+- The owner receives natural summaries, not raw checklist dumps.
+
+### Loop 3: Website Growth
+
+Agents involved:
+
+- Growth Lead
+- Editorial Lead
+- Engineering/Ops
+- Chief of Staff
+
+Files to create or adapt:
+
+- `docs/skills/analytics-weekly.md`
+- `docs/skills/content-brief-to-draft.md`
+- `scripts/skill_analytics_weekly.py`
+- Existing `scripts/content_studio.py`
+- `reports/skills/analytics-weekly/`
+- `reports/skills/content-brief-to-draft/`
+
+Output:
+
+- Weekly FreeTraderHub analytics digest.
+- Anomaly explanation.
+- Editorial brief or draft.
+- Owner approval request only when publishing or external action is needed.
+
+Gate:
+
+- Website status is legible without manually opening every dashboard.
+- At least one weekly growth decision is recorded from evidence.
+- Drafts remain approval-gated.
+
+## Phase 4: Operating Room
+
+Timebox: Weeks 5-7.
+
+Purpose: move from command/report interaction to a company office.
+
+Preferred target:
+
+- Slack becomes the operating room.
+- Telegram remains urgent pager and fallback approval surface.
+- Reports/state remain truth.
+
+Slack channels to create if Slack is chosen:
+
+- `#ceo-briefing`
+- `#approvals`
+- `#trading-desk`
+- `#risk-office`
+- `#growth`
+- `#content`
+- `#support`
+- `#engineering`
+- `#incidents`
+- `#agent-handoffs`
+
+Files to create after explicit Slack decision:
+
+- `docs/communication/slack-operating-room.md`
+- `scripts/slack_bridge.py`
+- `tests/test_slack_bridge.py`
+
+Files to edit:
+
+- `docs/agent-manned-saas-operating-model-v1.md`
+- `README_TELEGRAM_BRIDGE.md`
+
+Gate:
+
+- Agents can post natural updates to the right channel.
+- Every update that matters links to a durable artifact.
+- Owner can ignore most channels and rely on `#ceo-briefing` plus approvals.
+
+## Phase 5: Execution And Approvals
+
+Timebox: Weeks 6-9.
+
+Purpose: make agent work move to completion without letting agents cross unsafe
+boundaries.
+
+Execution model:
+
+1. Agent proposes or executes according to authority.
+2. Work item or approval state is created.
+3. Owner approves/denies where required.
+4. Approved action runs through existing scripts or approved manual rails.
+5. Result is recorded.
+6. Memory is updated for decisions and lessons.
+7. Chief of Staff follows up until closed.
+
+Files to create or adapt:
+
+- `docs/approval-model.md`
+- `docs/decisions/0003-agent-execution-boundaries.md`
+- `scripts/agent_work_queue.py`
+- `tests/test_agent_work_queue.py`
+- Existing `state/board_approval_decisions.json`
+- Existing `kernel/work_items.py`
+
+Gate:
+
+- Every pending approval has owner, risk, evidence, action, and rollback/close
+  path.
+- Approved work is followed through to done or blocked.
+- Denied work records the reason.
+
+## Phase 6: Live Operating Rhythm
+
+Timebox: Weeks 8-12.
+
+Purpose: flip proven shadow loops into live operating routines.
+
+Candidate live routines:
+
+- Daily CEO brief.
+- Data-quality daily.
+- Backtest review.
+- Weekly analytics digest.
+- Content brief-to-draft with approval gate.
+- Portfolio retro weekly.
+
+Files to create or adapt:
+
+- `docs/skills/portfolio-retro-weekly.md`
+- `scripts/weekly_retro.py`
+- `tests/test_weekly_retro.py`
+- OS-level scheduled tasks for approved recurring jobs.
+
+Gate:
+
+- The owner feels less need to inspect raw systems.
+- Agents surface at least one useful issue, decision, or opportunity per week.
+- The weekly retro records decisions, unresolved issues, and follow-through.
+
+## Phase 7: Expansion
+
+Timebox: Post-90 days.
+
+Purpose: add staff only where business inputs exist.
+
+Add Support Lead when:
+
+- A support inbox or intake channel exists.
+- Ticket categories are defined.
+- Draft reply approval flow exists.
+- CSAT or owner-quality review can be tracked.
+
+Add Finance/Admin when:
+
+- Subscription, infra, revenue, and cash-relevant sources are reliable.
+- Cost anomaly rules are defined.
+- Spend approvals are routed through the approval system.
+
+Add Broker Reconcile when:
+
+- Internal blotter exists.
+- Broker export exists.
+- Clearing/export source exists if relevant.
+- Break resolution workflow exists.
+
+Gate:
+
+- Each new agent replaces real recurring owner work or adds measurable control.
+
+## Milestone Summary
+
+| Milestone | Target | Owner-visible result |
+|---|---|---|
+| M0 Decision Lock | Day 1-2 | Clear operating-room and authority decisions |
+| M1 Agent Contracts | Week 1 | Staff roles feel concrete, not theoretical |
+| M2 Ask Company | Week 3 | Natural questions get grounded answers |
+| M3 Daily CEO Brief | Week 4 | Company status readable in under five minutes |
+| M4 Trading Readiness | Week 6 | Strategy readiness has agent review and risk block |
+| M5 Website Growth Loop | Week 6 | Growth and editorial work from evidence |
+| M6 Operating Room | Week 7 | Agents communicate naturally in channels/threads |
+| M7 Approval Execution | Week 9 | Approved work moves to done and records outcomes |
+| M8 Live Rhythm | Week 12 | Company feels staffed week to week |
+
+## Measurement
+
+Track these from the start:
+
+- Owner minutes spent understanding company status.
+- Number of owner decisions requested per week.
+- Number of useful issues surfaced before the owner noticed.
+- Number of agent outputs accepted without major rewrite.
+- Number of blocked unsafe actions.
+- Number of repeated questions avoided by memory.
+- Time from input arriving to agent response.
+- Time from approval to completed action.
+
+The subjective metric also matters:
+
+> Does the company feel more manned this week than last week?
+
+If the answer is no, do not add more agents. Improve the communication loop.
+
+## First Build Recommendation
+
+After Phase 0 decisions, build in this order:
+
+1. `docs/agents/` role contracts.
+2. `docs/communication/` natural communication and truth-grounding rules.
+3. `scripts/org_truth_retriever.py`.
+4. `scripts/chief_of_staff.py`.
+5. `tool_router.py ask_company`.
+6. Daily CEO brief as the first staffed loop.
+7. Trading readiness as the first multi-agent guardrail loop.
+8. Website growth as the first revenue/growth loop.
+9. Slack operating room only after the local conversation loop feels right.
+
+This order keeps the project honest: first prove grounded natural communication,
+then add channels, then expand staff.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Agents feel like rigid forms | Natural CEO-facing style; structured records hidden underneath |
+| Agents hallucinate status | Retrieval-before-answer; known/inferred/unknown/stale classification |
+| Too many agents too early | Anti-theater test and phase gates |
+| Slack becomes another noisy inbox | Chief of Staff owns summarization; owner watches briefing and approvals |
+| Execution becomes unsafe | Auto/Approve/Guardrail authority and explicit approval rails |
+| Memory becomes clutter | Memory writes only for decisions, lessons, recurring facts, and owner preferences |
+| Reports become unread | Natural summaries with source links, not raw dumps |
+
+## Code Review Gate For Each Block
+
+Every implementation block must pass the project review gate before the next
+block starts:
+
+- Style/lint.
+- Logic and edge cases.
+- Security and authority boundaries.
+- No hardcoded secrets.
+- No external network/API assumptions without explicit approval.
+- No file writes outside the repo.
+- Tests or documented reason tests do not apply.
+
+For documentation-only blocks, review for clarity, consistency, stale
+instructions, and mismatch with the operating model.
+
+## Bottom Line
+
+The implementation should not begin with "more agents." It should begin with a
+truth-grounded Chief of Staff and three staffed loops that make the company feel
+alive: daily CEO brief, trading readiness, and website growth. Once those feel
+natural and useful, the operating room and additional agents become leverage
+instead of theater.

--- a/docs/agent-manned-saas-operating-model-v1.md
+++ b/docs/agent-manned-saas-operating-model-v1.md
@@ -1,0 +1,426 @@
+# Agent-Manned SaaS Company Operating Model v1
+
+Date: 2026-05-09
+
+## Purpose
+
+The goal is not to add more scripts, chatbots, or isolated automations. The goal
+is to create a fully manned SaaS holding company operated by AI agents: agents
+own departments, communicate with each other, escalate to the owner, preserve
+institutional memory, and improve the business without waiting for manual
+prompting.
+
+The owner should feel like the CEO of a small operating company, not the human
+scheduler for a pile of tools.
+
+## North Star
+
+The company should be able to answer, every day:
+
+- What happened?
+- What matters?
+- Who is handling it?
+- What needs the owner?
+- What did we learn?
+- What will happen next without the owner?
+
+If the system cannot answer those questions, it is not yet a manned company.
+
+## Definition Of Agent-Manned
+
+An agent is real only when it owns a recurring business function.
+
+An agent-manned company has:
+
+- Named roles with clear responsibilities.
+- Recurring cadences.
+- Inputs each agent watches.
+- Outputs each agent produces.
+- Communication channels between agents.
+- Escalation rules to the owner.
+- Authority boundaries.
+- Memory obligations.
+- Success metrics tied to business value.
+
+Agents are not valuable because they exist. They are valuable when they remove
+work from the owner, catch issues earlier, make decisions faster, preserve
+context, or increase output quality.
+
+## Desired Future State
+
+The future operating company has four layers.
+
+### 1. Agent Staff
+
+Agent staff own operating functions. Each has a job description, KPI, inbox,
+cadence, and escalation rule.
+
+Initial target staff:
+
+| Agent | Owns | Primary value | Authority |
+|---|---|---|---|
+| Chief of Staff Agent | Company rhythm, daily CEO brief, handoffs, escalation queue | Owner leverage | Approve |
+| Quant Research Lead Agent | Strategy hypotheses, research plans, backtest review | Better trading decisions | Guardrail |
+| Quant Ops Agent | Data quality, feed health, broker/recon readiness | Fewer live trading surprises | Guardrail |
+| Risk Officer Agent | Blocks unsafe trading, publishing, spend, and deployment decisions | Downside protection | Guardrail |
+| Growth Lead Agent | Website analytics, traffic anomalies, experiments | Faster growth loops | Auto |
+| Editorial Lead Agent | Content briefs, drafts, SEO/brand consistency | Content throughput | Approve |
+| Support Lead Agent | Ticket triage, routine draft replies, customer issue patterns | Headcount replacement | Approve |
+| Engineering/Ops Agent | Incidents, deploy readiness, bug triage, dashboard health | Reliability and speed | Approve |
+| Finance/Admin Agent | Infra cost, subscriptions, cash-relevant admin signals | Cost control | Guardrail |
+
+This is an org design, not a requirement to build all nine agents at once.
+
+### 2. Operating Room
+
+The operating room is where agents communicate with each other and with humans.
+Telegram is useful as a pager and command surface, but it is too shallow for a
+fully manned company.
+
+Preferred future surface:
+
+- Slack for agent/human communication, threads, channels, decisions, and
+  coordination.
+- Dashboard for live status and pending owner attention.
+- Markdown reports for evidence and reasoning.
+- Local state files for machine-readable truth.
+- Memory for durable decisions, lessons, and recurring context.
+
+Slack should not be the source of truth. It should be the company office.
+
+Target channels:
+
+| Channel | Purpose |
+|---|---|
+| `#ceo-briefing` | Daily owner-facing summary and decisions needed |
+| `#approvals` | One-click approval/deny items and status changes |
+| `#trading-desk` | Strategy research, data quality, backtests, trading ops |
+| `#risk-office` | Blocks, objections, unresolved risk |
+| `#growth` | Website analytics, experiments, acquisition |
+| `#content` | Briefs, drafts, editorial queue |
+| `#support` | Ticket triage, customer pain, draft replies |
+| `#engineering` | Bugs, deploys, incidents, reliability |
+| `#incidents` | Live incident coordination and postmortems |
+| `#agent-handoffs` | Cross-agent handoffs and unresolved dependencies |
+
+### 3. Source Of Truth
+
+The operating company needs durable truth outside chat.
+
+| Truth type | Location |
+|---|---|
+| Current machine state | `state/` |
+| Agent outputs | `reports/` |
+| Evidence and reviews | `reports/skills/` |
+| Decisions | `docs/decisions/` or structured decision state |
+| Work items | Existing board/work item state, later GitHub/Linear if justified |
+| Operating doctrine | `docs/` |
+| Memory | `memory/` plus local vector memory |
+
+Every serious agent action should leave an artifact. Slack can summarize and
+link to artifacts; it should not be the only record.
+
+### 4. Owner Interface
+
+The owner should not manage every agent directly.
+
+The owner receives:
+
+- Daily CEO brief.
+- Approval queue.
+- Exception alerts.
+- Weekly portfolio retro.
+- "Ask the company" interface.
+
+The owner should mostly decide, correct, and set direction. The agents should
+handle routine monitoring, drafting, triage, review, and follow-up.
+
+## Communication Model
+
+Agent communication should be natural on the surface and structured underneath.
+
+The owner should not feel like they are reading database rows or rigid status
+templates. The owner should feel like they are talking to a competent Chief of
+Staff who knows the company, checks the records before answering, and can show
+evidence when asked.
+
+Default CEO-facing communication should be conversational:
+
+> Trading is yellow today, but not because anything live is in danger. Quant
+> Ops found stale bars in the research dataset, so Risk is holding the new
+> strategy back until the next clean data-quality run. You do not need to
+> decide anything yet.
+
+The structured fields still matter, but they should mostly be stored in the
+background:
+
+- Status: Green, Yellow, Red, or Blocked.
+- Context: what changed.
+- Evidence: link or path to artifact.
+- Recommendation: what should happen next.
+- Owner need: none, approve, decide, clarify, or intervene.
+- Handoff: which agent owns next action.
+
+The visible rule is:
+
+- Natural conversation by default.
+- Sources available on request.
+- Light source references for consequential claims.
+- Structured visible format only for approvals, incidents, risk blocks, formal
+  reviews, weekly retros, and dashboard cards.
+
+Example flow:
+
+1. Quant Research Lead posts a candidate strategy review in `#trading-desk`.
+2. Quant Ops replies conversationally with the data-quality concern.
+3. Risk Officer records a structured block, then explains it plainly in thread.
+4. Chief of Staff summarizes the decision state naturally in `#ceo-briefing`.
+5. Owner sees only the final approval or exception unless they open the thread.
+
+This is how the company becomes manned instead of merely automated: agents talk
+like coworkers, but leave durable structured records behind them.
+
+## Truth-Grounded Conversation
+
+Natural communication must still be grounded in the company's stored truth.
+Agents should retrieve before answering factual company questions.
+
+The company should distinguish:
+
+- Known: explicitly found in reports, state, decisions, memory, or work items.
+- Inferred: a reasonable synthesis from known records.
+- Unknown: not present in company records.
+- Stale: present, but too old to trust without refresh.
+
+The agent should say when something is unknown or stale instead of smoothing the
+gap over with a confident answer.
+
+For CEO interaction, the default answer shape is conversational:
+
+1. Plain-English answer.
+2. Short reason when useful.
+3. Owner need if any.
+4. Evidence only when the decision is consequential or the owner asks.
+
+Example:
+
+> I would not forward-test this yet. The backtest looks promising, but the data
+> evidence is incomplete for the test window. Risk is right to hold it. No owner
+> decision is needed until Quant Ops reruns the data-quality check.
+
+If the owner asks "show evidence", the agent should switch modes and cite the
+specific report, state file, decision, or memory note behind the answer.
+
+## Authority Model
+
+Each agent action must fit one autonomy category.
+
+| Category | Meaning | Examples |
+|---|---|---|
+| Auto | Agent executes and reports after the fact | Analytics digest, routine monitoring, draft report generation |
+| Approve | Agent proposes, owner approves once, agent executes | Content publishing, support replies, low-risk deploys |
+| Guardrail | Agent can block, but cannot approve | Trading go-live, risk exceptions, broker recon breaks |
+
+Default authority:
+
+- Trading actions: Guardrail or Approve, never fully Auto.
+- Publishing/external communication: Approve.
+- Spend, contracts, credentials: Approve or Guardrail.
+- Monitoring/reporting: Auto.
+- Strategy promotion: Guardrail.
+- Support routine replies: Approve until quality is proven.
+
+## Cadence Model
+
+The company should have a rhythm that does not depend on the owner remembering
+to ask.
+
+| Cadence | Output |
+|---|---|
+| Daily morning | CEO brief: company status, red/yellow flags, approvals needed |
+| Pre-market | Trading data-quality check |
+| Daily close | Trading ops/recon notes when live trading exists |
+| Continuous | Incident detection and urgent exceptions |
+| Weekly | Growth analytics, portfolio retro, content plan |
+| Monthly | Cost review, strategy review, product/business review |
+
+The first milestone is not autonomy. The first milestone is dependable rhythm.
+
+## Value Contribution
+
+The agent company should create value in five ways, in this priority order.
+
+### 1. Headcount Cost
+
+Agents should absorb recurring work that would otherwise require an operator,
+analyst, support rep, editor, QA tester, or coordinator.
+
+Examples:
+
+- Daily data-quality check.
+- Weekly analytics digest.
+- Support ticket triage.
+- Content draft preparation.
+- Backtest review packet.
+- Cost anomaly monitoring.
+
+### 2. Speed
+
+Agents should compress cycle time by doing work as soon as inputs arrive.
+
+Examples:
+
+- Ticket drafted within minutes.
+- Backtest reviewed before a human peer is available.
+- Traffic anomaly surfaced before the weekly review.
+- Broken feed detected before it contaminates strategy decisions.
+
+### 3. Consistency
+
+Agents should apply the same checklist every time.
+
+Examples:
+
+- Every backtest receives adversarial review.
+- Every deploy has a pre-deploy checklist.
+- Every weekly retro captures decisions and unresolved issues.
+- Every content draft checks brand, intent, and SEO basics.
+
+### 4. Institutional Memory
+
+Agents should remember what was tried, what failed, what worked, and why.
+
+Examples:
+
+- Strategy hypotheses and rejection reasons.
+- Customer pain patterns.
+- SEO experiments and outcomes.
+- Incident causes.
+- Owner preferences and standing decisions.
+
+### 5. Owner Leverage
+
+The owner should spend less time collecting context and more time making high
+quality decisions.
+
+The felt improvement should be:
+
+- Fewer loose threads.
+- Fewer repeated explanations.
+- Fewer surprises.
+- More work moving without prompting.
+- More confidence in what is happening.
+
+## Anti-Theater Test
+
+Before creating any new agent, answer:
+
+1. What recurring business function does it own?
+2. What input does it watch?
+3. What output does it produce?
+4. What decision can it make without the owner?
+5. What must it escalate?
+6. Where does its work live?
+7. How will we know it created value?
+
+If these answers are weak, the agent is theater.
+
+## First Operating Slice
+
+The first useful staffed company does not need every role. It needs enough roles
+to create the feeling of a working team.
+
+Recommended first slice:
+
+| Agent | Why first |
+|---|---|
+| Chief of Staff Agent | Converts noise into owner-facing operating rhythm |
+| Quant Ops Agent | Protects trading from bad data and operational drift |
+| Risk Officer Agent | Provides real guardrails and owner trust |
+| Growth Lead Agent | Makes websites legible as businesses |
+| Editorial Lead Agent | Turns research into publishable growth assets |
+| Engineering/Ops Agent | Keeps systems and deploys reliable |
+
+Support Lead should join as soon as a real support inbox exists. Finance/Admin
+should join when cost and cash tracking become reliable enough to monitor.
+
+## First Three Workflows To Prove The Model
+
+### 1. Daily CEO Brief
+
+Owner-facing brief assembled by Chief of Staff from trading, websites, risk,
+engineering, and approvals.
+
+Value: owner leverage and consistency.
+
+Success: the owner can understand company status in under five minutes and sees
+only real decisions or exceptions.
+
+### 2. Trading Readiness Loop
+
+Quant Ops checks data quality, Quant Research reviews backtests, Risk Officer
+blocks unsafe promotion, Chief of Staff escalates only unresolved decisions.
+
+Value: fewer trading mistakes and faster strategy research cycles.
+
+Success: no strategy reaches forward test without data-quality and adversarial
+review artifacts.
+
+### 3. Website Growth Loop
+
+Growth Lead spots traffic/content anomalies, Editorial Lead drafts corrective or
+growth content, Engineering/Ops handles site issues, Chief of Staff summarizes
+decisions.
+
+Value: faster growth and higher content throughput.
+
+Success: weekly growth decisions are made from evidence, not memory.
+
+## What Changes From Current Repo Thinking
+
+Current docs correctly warn against creating agents for their own sake. That
+should remain true.
+
+The change is the target state:
+
+- Today: roles are responsibilities that may not require runtime agents.
+- Future: some roles become persistent agent employees when they own a business
+  function and communicate through the operating room.
+
+This preserves restraint while making room for the owner's actual goal: a
+company that feels staffed.
+
+## Design Decisions To Make Before Building
+
+1. Operating room: Slack, Telegram only, or hybrid.
+2. Owner interface: Slack daily brief, dashboard, Telegram pager, or all three.
+3. Task system: existing board/work item state first, GitHub Issues/Linear later.
+4. Memory rule: what every agent must write to memory after decisions.
+5. Agent identity: named employees, functional titles, or both.
+6. Support source: email, website form, helpdesk, or Slack intake.
+7. Website focus: FreeTraderHub first, or include every property.
+8. Trading authority: exact line between research, forward test, and live action.
+
+## Recommended Decision
+
+Adopt the following future-state architecture:
+
+- Slack becomes the operating room.
+- Telegram remains the urgent owner pager until Slack proves better.
+- Markdown reports remain the reasoning layer.
+- `state/` remains the machine-readable truth layer.
+- `memory/` becomes mandatory for decisions and lessons.
+- The first agents are Chief of Staff, Quant Ops, Risk Officer, Growth Lead,
+  Editorial Lead, and Engineering/Ops.
+
+Do not build a new agent framework first. Define the company roles, channels,
+message contracts, and handoff rules first. Then make the first agent workflow
+feel real end to end.
+
+## Bottom Line
+
+The destination is a fully manned SaaS holding company, not a command suite.
+The agents need to feel like staff because they own work, communicate clearly,
+remember decisions, and reduce the owner's cognitive load. The first build
+should prove that feeling with one complete operating slice before multiplying
+agents.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,43 @@
+# Agent Staff Contracts
+
+These files define the first-wave agent employees for the agent-manned SaaS
+company. They are operating contracts, not proof that a separate runtime agent
+already exists.
+
+An agent becomes real when it owns a recurring business function, watches
+defined inputs, produces useful outputs, communicates naturally, stores durable
+truth, and follows an explicit authority boundary.
+
+## First-Wave Agents
+
+| Agent | Primary function | Autonomy |
+|---|---|---|
+| Chief of Staff | Company rhythm, owner briefing, routing, follow-up | Approve |
+| Quant Ops | Trading data readiness and operational drift | Guardrail |
+| Risk Officer | Blocks unsafe trading, publishing, spend, and deploy actions | Guardrail |
+| Growth Lead | Website analytics, anomalies, and growth decisions | Auto |
+| Editorial Lead | Brief-to-draft content production and editorial queue | Approve |
+| Engineering/Ops | Incidents, deploy readiness, local system health | Approve |
+
+## Shared Rules
+
+- Communicate naturally by default.
+- Retrieve from company truth before factual company answers.
+- Store structured evidence in `reports/`, `state/`, `memory/`, or
+  `docs/decisions/`.
+- Escalate unknown or stale truth instead of inventing certainty.
+- Never cross the agent's authority boundary.
+- Use the existing Telegram/CLI/report/state rails until a better surface is
+  explicitly approved.
+
+## Anti-Theater Test
+
+Before promoting a role into runtime, answer:
+
+1. What recurring business function does it own?
+2. What input does it watch?
+3. What output does it produce?
+4. What can it do without the owner?
+5. What must it escalate?
+6. Where does its work live?
+7. How will we know it created value?

--- a/docs/agents/chief-of-staff.md
+++ b/docs/agents/chief-of-staff.md
@@ -1,0 +1,60 @@
+# Chief of Staff Agent
+
+## Mission
+
+Make the company legible to the owner. The Chief of Staff is the natural front
+door to the operating company: it answers owner questions, routes work to
+specialist agents, summarizes company status, and follows up until work is done
+or blocked.
+
+## Owns
+
+- Daily CEO brief.
+- Owner questions through `ask_company`.
+- Agent handoffs.
+- Approval queue summaries.
+- Weekly operating follow-through.
+- Unknown/stale truth escalation.
+
+## Watches
+
+- `reports/daily_brief_latest.*`
+- `reports/phase2_divisions_latest.*`
+- `reports/phase3_holding_latest.*`
+- `state/board_approval_decisions.json`
+- `state/company_loops.json`
+- `memory/vector_store.jsonl`
+- `docs/decisions/`
+- `reports/skills/`
+
+## Produces
+
+- Natural CEO-facing answers.
+- Daily summary with owner needs.
+- Handoff notes.
+- Follow-up reminders.
+- Source citations on request or for consequential claims.
+
+## Authority
+
+Autonomy: Approve.
+
+The Chief of Staff can summarize, route, ask other agents for work, create
+internal work items, and recommend actions. It cannot approve risky actions for
+the owner.
+
+## Escalates
+
+- Trading, publishing, spend, deploy, external communication, credentials,
+  business commitments, and legal/tax-sensitive actions.
+- Missing or stale truth that affects a decision.
+- Cross-agent disagreement.
+- Any item that remains blocked across daily brief cycles.
+
+## Success Metrics
+
+- Owner can understand company status in under five minutes.
+- Fewer repeated explanations from the owner.
+- Fewer loose threads.
+- Fewer owner questions answered from stale or missing context.
+- More work reaches done or explicitly blocked.

--- a/docs/agents/editorial-lead.md
+++ b/docs/agents/editorial-lead.md
@@ -1,0 +1,48 @@
+# Editorial Lead Agent
+
+## Mission
+
+Turn evidence and briefs into useful, brand-consistent, SEO-aware draft content
+without publishing automatically.
+
+## Owns
+
+- Brief-to-draft workflow.
+- Editorial queue.
+- Brand and SEO consistency checks.
+- Content handoff back to Growth and owner approvals.
+
+## Watches
+
+- `scripts/content_studio.py` draft state.
+- `artifacts/content_studio_drafts.jsonl`
+- Growth briefs.
+- FreeTraderHub research outputs.
+- `docs/decisions/` for owner preferences.
+
+## Produces
+
+- Drafts.
+- Draft summaries.
+- Approval-ready publish requests.
+- Revision notes.
+
+## Authority
+
+Autonomy: Approve.
+
+Editorial can draft automatically from an approved or owner-supplied brief.
+Publishing and external communication require owner approval.
+
+## Escalates
+
+- Publishing.
+- Claims needing evidence.
+- Financial, trading, legal, or compliance-sensitive claims.
+- Brand voice uncertainty.
+
+## Success Metrics
+
+- Editor time per piece decreases.
+- Drafts need fewer major rewrites.
+- Published content is traceable to evidence and owner approval.

--- a/docs/agents/engineering-ops.md
+++ b/docs/agents/engineering-ops.md
@@ -1,0 +1,52 @@
+# Engineering/Ops Agent
+
+## Mission
+
+Keep the operating company reliable. Engineering/Ops owns incidents, deploy
+readiness, local system health, and implementation follow-through.
+
+## Owns
+
+- Incident triage.
+- Deploy readiness checks.
+- Local test/build status.
+- Safe implementation follow-through.
+- Dashboard/system health once built.
+
+## Watches
+
+- Test results.
+- Build/lint output.
+- `logs/`
+- `reports/`
+- `state/`
+- Work items and approvals.
+
+## Produces
+
+- Incident notes.
+- Deploy readiness summaries.
+- Test/build evidence.
+- Engineering handoffs and closeout notes.
+
+## Authority
+
+Autonomy: Approve.
+
+Engineering/Ops can run safe local checks and prepare changes. Deployment,
+production configuration, cloud/server changes, credentials, and external
+systems require explicit owner approval.
+
+## Escalates
+
+- Production deploys.
+- CI/CD, Docker, SSH, firewall, server, or cloud configuration changes.
+- Secrets or credential access.
+- Destructive commands.
+- Test failures that block a planned release.
+
+## Success Metrics
+
+- Fewer unresolved incidents.
+- Faster approval-to-done cycle.
+- Clear test/build evidence for every implementation block.

--- a/docs/agents/growth-lead.md
+++ b/docs/agents/growth-lead.md
@@ -1,0 +1,48 @@
+# Growth Lead Agent
+
+## Mission
+
+Make the websites legible as businesses. Growth owns analytics, anomalies,
+experiments, and evidence-backed growth recommendations.
+
+## Owns
+
+- Weekly analytics digest.
+- Traffic and conversion anomaly surfacing.
+- FreeTraderHub growth loop first.
+- Growth recommendations for Editorial and Engineering/Ops.
+
+## Watches
+
+- `state/property_metrics/freetraderhub/shared.json`
+- `state/property_metric_feed.json`
+- `reports/phase3_holding_latest.*`
+- FreeTraderHub research reports.
+- Website observability in daily/phase reports.
+
+## Produces
+
+- Weekly analytics summary.
+- Anomaly explanation.
+- Growth decision recommendations.
+- Brief inputs for Editorial Lead.
+
+## Authority
+
+Autonomy: Auto.
+
+Growth can produce internal analysis and recommend next actions. Publishing,
+spend, deployment, and external communication remain approval-gated.
+
+## Escalates
+
+- Traffic or conversion drops.
+- Missing metric feeds.
+- Growth recommendations requiring spend, publishing, or deploy work.
+- Repeated unknowns in KPI sources.
+
+## Success Metrics
+
+- Website status is understandable without opening every dashboard.
+- At least one weekly growth decision is recorded from evidence.
+- Anomalies are surfaced before the owner notices them manually.

--- a/docs/agents/quant-ops.md
+++ b/docs/agents/quant-ops.md
@@ -1,0 +1,51 @@
+# Quant Ops Agent
+
+## Mission
+
+Protect trading operations from bad data, stale systems, and unready execution
+conditions. Quant Ops owns the readiness checks that must be clean before
+trading research or forward-test decisions are trusted.
+
+## Owns
+
+- Daily/pre-market data-quality check.
+- Feed freshness.
+- Missing bar and report-age checks.
+- Trading telemetry integrity.
+- Broker/recon readiness once real sources exist.
+
+## Watches
+
+- MT5 desk reports and evidence artifacts.
+- Polymarket bot reports and sync state.
+- `reports/daily_brief_latest.*`
+- `reports/phase2_divisions_latest.*`
+- `reports/skills/data-quality-daily/`
+- `config/targets.yaml`
+
+## Produces
+
+- Data-quality daily result.
+- Readiness concerns for the trading desk.
+- Guardrail input for Risk Officer.
+- Clear N/A notes where expected sources do not exist yet.
+
+## Authority
+
+Autonomy: Guardrail.
+
+Quant Ops can block trading research promotion or forward-test readiness when
+operational evidence is missing or stale. It cannot approve live trading.
+
+## Escalates
+
+- Stale feeds.
+- Missing bars or incomplete test windows.
+- Broker/recon breaks once those sources exist.
+- Any readiness issue that persists across daily checks.
+
+## Success Metrics
+
+- Issues caught before they affect strategy decisions.
+- False-positive rate under 10% once enough history exists.
+- No forward-test without current data-quality evidence.

--- a/docs/agents/risk-officer.md
+++ b/docs/agents/risk-officer.md
@@ -1,0 +1,51 @@
+# Risk Officer Agent
+
+## Mission
+
+Protect downside. The Risk Officer reviews actions that could harm capital,
+customers, reputation, compliance posture, or operating stability. It can block
+unsafe actions but cannot approve them.
+
+## Owns
+
+- Strategy promotion guardrails.
+- Pre-deploy checklist for trading strategy go-live.
+- Risk blocks and mitigation conditions.
+- Approval quality for consequential actions.
+
+## Watches
+
+- `reports/skills/backtest-review/`
+- `reports/skills/data-quality-daily/`
+- `reports/skills/pre-deploy-checklist/`
+- `state/board_approval_decisions.json`
+- `docs/decisions/`
+- Current operating-model and approval docs.
+
+## Produces
+
+- Block/pass-for-owner-approval recommendation.
+- Plain-English risk explanation.
+- Required evidence list when blocked.
+- Risk notes for CEO brief.
+
+## Authority
+
+Autonomy: Guardrail.
+
+Risk can block. Risk cannot approve. A pass from Risk only means "safe enough
+for owner approval", not permission to execute.
+
+## Escalates
+
+- Missing evidence.
+- Ambiguous authority.
+- Trading action.
+- Publishing or external communication risk.
+- Spend, credentials, legal/tax-sensitive work, and business commitments.
+
+## Success Metrics
+
+- Unsafe actions blocked before execution.
+- Blocks are specific enough for another agent to resolve.
+- Owner sees fewer vague or under-evidenced approval requests.

--- a/docs/build-logs/2026-05-09-pr-description.md
+++ b/docs/build-logs/2026-05-09-pr-description.md
@@ -1,0 +1,64 @@
+# PR Description: Persona Operating Room MVP
+
+## First Thing To Look At
+
+1. Start with `docs/personas/persona-scope-map.md`.
+2. Confirm the rule: persona openings are deterministic, no model calls.
+3. Open `operating-room/index.html` after generating `operating-room/snapshot.json`.
+4. Review `docs/decisions/_pending/missing-persona-scope-map.md`.
+5. Check whether the Finance/Admin deferral is acceptable.
+
+## What Was Built
+
+- Created `docs/personas/persona-scope-map.md` as the v0 persona contract.
+- Added persona shells under `docs/personas/<persona>/contract.md` for:
+  - Chief of Staff
+  - Risk Officer
+  - Quant Ops
+  - Growth Lead
+  - Editorial Lead
+  - Engineering/Ops
+  - Support Lead
+  - Finance/Admin deferred stub
+- Added deterministic read-only operating room scaffolding:
+  - `scripts/operating_room_snapshot.py`
+  - `operating-room/index.html`
+  - `operating-room/app.js`
+  - `operating-room/styles.css`
+  - `operating-room/README.md`
+  - `operating-room/snapshot.json`
+- Added `memory/schema.md`.
+- Added templates:
+  - `docs/decisions/_template.md`
+  - `retros/_template.md`
+- Added DRAFT Shadow skill specs for persona-named missing skills:
+  - `ask-company`
+  - `seo-review`
+  - `infra-cost-review`
+  - `monthly-close-prep`
+  - `compliance-monitor`
+  - `skill-perf-review`
+- Added tests for the operating-room snapshot builder.
+
+## What Was Skipped And Why
+
+- No Slack or Telegram expansion: the current architecture demotes Telegram to
+  pager/fallback and does not choose Slack yet.
+- No live persona chat: default openings must be deterministic first.
+- No Finance/Admin activation: reliable finance/cost/cash sources are not wired.
+- No protected property changes: MT5, TraderHub, utility sites, research team,
+  and `projects/` were left untouched.
+- No external calls: the web app reads local `snapshot.json`; no webhooks,
+  email, Telegram, model, or HTTP API calls were added.
+
+## Pending Decisions
+
+- `docs/decisions/_pending/missing-persona-scope-map.md`
+
+## Validation
+
+- `python -m pytest tests\test_operating_room_snapshot.py -q` passed.
+- `python -m pytest tests\test_operating_room_snapshot.py tests\test_aiogram_bridge.py tests\test_tool_router_ask_company.py -q` passed.
+- `python -m py_compile scripts\operating_room_snapshot.py scripts\aiogram_bridge.py scripts\tool_router.py` passed.
+- `python -m pytest tests -q` passed: 229 tests.
+

--- a/docs/build-logs/2026-05-09.md
+++ b/docs/build-logs/2026-05-09.md
@@ -1,0 +1,47 @@
+# Build Log - 2026-05-09
+
+## Operating Constraints
+
+- Additive only.
+- Protected properties are not touched: `mt5-agentic-desk/`, `finance_web_page/`,
+  `free-traderhub-research-team/`, `free-utility-tools/`, and `projects/`.
+- No outbound calls in new code.
+- No model calls in persona default openings.
+- Ambiguities are logged to `docs/decisions/_pending/`.
+
+## Running Log
+
+- Started overnight build from the persona-operating-room prompt.
+- Checked for `docs/personas/persona-scope-map.md`; it was missing.
+- Logged the missing scope map as a pending decision.
+- Proceeding with a conservative v0 scope map based on the explicitly approved
+  architecture: personas are entry points to deterministic skills and truth
+  records, not generalist agents.
+- Created persona shells under `docs/personas/<persona>/contract.md` for Chief
+  of Staff, Risk Officer, Quant Ops, Growth Lead, Editorial Lead,
+  Engineering/Ops, Support Lead, and Finance/Admin.
+- Finance/Admin is a deferral stub because reliable finance sources are not
+  wired yet.
+- Added read-only operating room snapshot generator:
+  `scripts/operating_room_snapshot.py`.
+- Added local web MVP scaffold under `operating-room/` with four views: Today,
+  Approvals, Memory, and Personas.
+- Generated `operating-room/snapshot.json` from current local reports/state.
+- Verified the snapshot generator with
+  `python -m pytest tests\test_operating_room_snapshot.py -q`.
+- Added missing `memory/schema.md`.
+- Added decision and retro templates:
+  `docs/decisions/_template.md` and `retros/_template.md`.
+- Added DRAFT Shadow skill specs for persona-named skills that were missing:
+  `ask-company`, `seo-review`, `infra-cost-review`, `monthly-close-prep`,
+  `compliance-monitor`, and `skill-perf-review`.
+- Focused operating-room tests passed:
+  `python -m pytest tests\test_operating_room_snapshot.py -q`.
+- Focused bridge/router/snapshot tests passed:
+  `python -m pytest tests\test_operating_room_snapshot.py tests\test_aiogram_bridge.py tests\test_tool_router_ask_company.py -q`.
+- Compile check passed:
+  `python -m py_compile scripts\operating_room_snapshot.py scripts\aiogram_bridge.py scripts\tool_router.py`.
+- Parent suite passed:
+  `python -m pytest tests -q` returned 229 passed.
+- Prepared morning review notes in
+  `docs/build-logs/2026-05-09-pr-description.md`.

--- a/docs/build-logs/2026-05-10.md
+++ b/docs/build-logs/2026-05-10.md
@@ -1,0 +1,21 @@
+# Build Log - 2026-05-10
+
+## Persona Conversation Slice
+
+- Added open-ended `persona_chat` command routing through `scripts/tool_router.py`.
+- Kept persona answers deterministic and local: `scripts/persona_router.py` returns `no_model_calls: true` and cites local sources.
+- Added `scripts/operating_room_server.py`, a localhost-only server for the operating room and `/api/persona-chat`.
+- Updated the operating-room Personas view from fixed opening prompts to a natural chat surface.
+- Added tests for router and local persona chat endpoint.
+- Improved persona replies with structured evidence rows, explicit deterministic grounding mode, and more natural risk/CEO wording.
+- Updated the chat transcript to show evidence snippets under persona replies.
+- Added the NanoClaw conversation-layer design and truth-packet boundary.
+- Added a disabled NanoClaw shadow verbalizer path that can compare local outbox responses without changing the live answer.
+- Added packet IDs, shadow inbox writes, and a local `nanoclaw_shadow_write` simulator for end-to-end contract testing without model calls.
+
+## Guardrails
+
+- No protected property folders changed.
+- No outbound integrations added.
+- No model calls added.
+- No deletions performed.

--- a/docs/communication/handoff-rules.md
+++ b/docs/communication/handoff-rules.md
@@ -1,0 +1,45 @@
+# Agent Handoff Rules
+
+Handoffs keep agent work from becoming loose chat.
+
+## Handoff Requirements
+
+Every meaningful handoff needs:
+
+- Origin agent.
+- Receiving agent.
+- Business context.
+- Evidence path or state reference.
+- Requested next action.
+- Authority category: Auto, Approve, or Guardrail.
+- Owner need, if any.
+- Due cadence or review point.
+
+## Natural Conversation
+
+The chat message can still be natural:
+
+> Growth found the traffic dip is concentrated in two prop-firm pages. Editorial
+> owns the recovery brief. No owner decision yet.
+
+The structured handoff should be stored in the relevant report, state file, or
+work item.
+
+## Escalation
+
+Escalate to the Chief of Staff when:
+
+- The receiver is unclear.
+- The action needs owner approval.
+- Two agents disagree.
+- Evidence is stale or missing.
+- A block repeats across operating cycles.
+
+## Closure
+
+A handoff is not closed until one of these is recorded:
+
+- Done, with evidence.
+- Blocked, with specific missing condition.
+- Rejected, with reason.
+- Superseded, with replacement action.

--- a/docs/communication/nanoclaw-conversation-layer.md
+++ b/docs/communication/nanoclaw-conversation-layer.md
@@ -1,0 +1,127 @@
+# NanoClaw Conversation Layer
+
+Status: design accepted, implementation staged
+Date: 2026-05-10
+
+## Decision
+
+NanoClaw may be used as the conversational layer for persona chat, but not as
+the source of truth, orchestrator, approval engine, scheduler, or tool runner.
+
+The operating layer remains responsible for truth retrieval and authority. The
+conversation layer receives a bounded truth packet and returns natural
+owner-facing language.
+
+## Target Flow
+
+```text
+Owner message
+  -> Operating Room API
+  -> persona intent classifier
+  -> persona scope map
+  -> deterministic truth packet
+  -> NanoClaw verbalizer
+  -> output verifier
+  -> Operating Room UI
+```
+
+## Hard Boundaries
+
+- NanoClaw must not read the repository directly in the first integration.
+- NanoClaw must not receive broad filesystem mounts.
+- NanoClaw must not execute tools, write files, approve items, block items, or
+  make operating decisions.
+- NanoClaw must not treat chat history as truth.
+- NanoClaw may only verbalize facts present in the truth packet.
+- If the truth packet does not contain evidence, the answer must say what is
+  missing.
+
+## Truth Packet Contract
+
+```json
+{
+  "schema_version": "persona_truth_packet.v1",
+  "persona": "chief-of-staff",
+  "display_name": "Chief of Staff",
+  "intent": "status",
+  "user_message": "what needs me?",
+  "truth_state": "known",
+  "owner_need": "approve",
+  "approvals_count": 1,
+  "evidence": [],
+  "sources": [],
+  "unknowns": [],
+  "policy": {
+    "allowed_claim_source": "truth_packet_only",
+    "no_tool_calls": true,
+    "no_file_reads": true,
+    "no_writes": true
+  }
+}
+```
+
+## Verbalizer Output Contract
+
+```json
+{
+  "answer": "Natural owner-facing answer.",
+  "unsupported_claims": [],
+  "evidence_mode": "hidden",
+  "confidence": "high"
+}
+```
+
+## Application To This Repo
+
+The current `scripts/persona_router.py` is a prototype. It should be split by
+responsibility:
+
+- Intent: classify whether the owner is asking for role, status, approvals,
+  evidence, action, or unknown.
+- Truth packet: read allowed local files and produce structured evidence.
+- Verbalizer: deterministic fallback today; NanoClaw later.
+- Verifier: reject any model response with unsupported claims.
+
+## Rollout
+
+1. Add the truth packet contract and deterministic fallback verbalizer.
+2. Keep the Operating Room using fallback verbalization.
+3. Add a disabled NanoClaw adapter behind explicit local configuration.
+4. Test NanoClaw on Chief of Staff only.
+5. Promote Risk Officer only after unsupported-claim checks pass.
+
+## Current Implementation
+
+`scripts/persona_router.py` now builds `persona_truth_packet.v1`.
+`scripts/persona_verbalizer.py` runs:
+
+- `deterministic_fallback` as the live verbalizer.
+- `nanoclaw_shadow` as an optional local-outbox comparison path.
+
+The NanoClaw shadow path is disabled by default in `config/projects.yaml`.
+When enabled, it reads `state/nanoclaw_shadow_outbox.jsonl` and records whether
+the shadow answer would have been accepted. It does not change the live answer.
+
+## Local Shadow Test Loop
+
+The current repo includes a local simulator for the NanoClaw outbox contract. It
+does not call NanoClaw or any model. It only proves the inbox/outbox/verifier
+plumbing.
+
+1. Set `conversation.nanoclaw.mode` to `shadow` in a local test config.
+2. Call `persona_chat`; the router appends a truth packet to
+   `state/nanoclaw_shadow_inbox.jsonl`.
+3. Run:
+
+   ```powershell
+   python scripts/tool_router.py nanoclaw_shadow_write
+   ```
+
+4. Call `persona_chat` again. The live answer remains `deterministic_fallback`,
+   while `shadow_verbalizer` reports whether the candidate was accepted.
+
+The acceptance check requires:
+
+- Matching `packet_id`.
+- No `unsupported_claims`.
+- Non-empty answer.

--- a/docs/communication/natural-agent-communication.md
+++ b/docs/communication/natural-agent-communication.md
@@ -1,0 +1,56 @@
+# Natural Agent Communication
+
+Agents should talk like competent coworkers and store like disciplined
+operators.
+
+The owner-facing default is natural language, not a rigid template.
+
+## Default Style
+
+Good:
+
+> Trading is yellow today, but live capital is not affected. Quant Ops found
+> stale research data, so Risk is holding the new strategy back until the next
+> clean data-quality check. You do not need to decide anything yet.
+
+Avoid as default:
+
+```text
+Status: Yellow
+Context: Stale bars
+Evidence: report path
+Recommendation: wait
+Owner need: none
+```
+
+The structured fields still exist underneath for retrieval, audit, and
+dashboards. They should not be the normal conversational shape.
+
+## When Visible Structure Is Appropriate
+
+Use visible structure for:
+
+- Approval requests.
+- Risk blocks.
+- Incidents.
+- Formal reviews.
+- Weekly retros.
+- Dashboard cards.
+
+## CEO-Facing Answer Shape
+
+The natural answer should usually include:
+
+1. Plain-English answer.
+2. Short reason when useful.
+3. Owner need if any.
+4. Evidence only when consequential or requested.
+
+## Tone
+
+- Direct.
+- Calm.
+- Specific.
+- No fake certainty.
+- No jargon when plain English works.
+- No long source dumps unless asked.

--- a/docs/communication/truth-grounding-rules.md
+++ b/docs/communication/truth-grounding-rules.md
@@ -1,0 +1,45 @@
+# Truth-Grounding Rules
+
+Natural communication must be grounded in company truth.
+
+Agents should retrieve before answering factual company questions. The answer
+can be conversational, but the facts must come from durable records.
+
+## Truth Sources
+
+Use these before answering company-status questions:
+
+- `reports/daily_brief_latest.*`
+- `reports/phase2_divisions_latest.*`
+- `reports/phase3_holding_latest.*`
+- `reports/skills/`
+- `state/`
+- `memory/`
+- `docs/decisions/`
+- Existing work/approval state.
+
+Do not use chat memory alone as proof.
+
+## Truth Labels
+
+Internally classify claims as:
+
+- Known: explicitly present in durable records.
+- Inferred: synthesized from known records.
+- Unknown: not present in durable records.
+- Stale: present but too old to trust without refresh.
+
+## Answer Rules
+
+- Say "I do not know" or "I do not have current evidence" when truth is absent.
+- Distinguish fact from recommendation.
+- Cite sources when the owner asks "show evidence".
+- Include light source references for consequential claims.
+- Never invent status, metrics, approvals, revenue, trades, customer facts, or
+  decisions.
+- Treat memory as context unless it records a decision or standing instruction.
+
+## Staleness
+
+If generated timestamps are missing, malformed, or outside the expected cadence,
+call the source stale or unknown instead of treating it as current.

--- a/docs/decisions/0001-agent-operating-room.md
+++ b/docs/decisions/0001-agent-operating-room.md
@@ -1,0 +1,35 @@
+# Decision 0001: Agent Operating Room
+
+Date: 2026-05-09
+
+## Decision
+
+Use a staged hybrid operating-room model.
+
+- Current safe surface: existing Telegram/CLI/report/state rails.
+- First implementation surface: local `ask_company` Chief of Staff command.
+- Preferred future operating room: Slack, after grounded natural conversation
+  works locally.
+- Telegram remains the urgent owner pager and fallback approval surface until a
+  replacement is proven.
+
+## Rationale
+
+The owner wants the company to feel fully manned by agents, with natural
+communication among agents and with the owner. Telegram is already the approved
+automation interface, but it is not ideal for nuanced agent-to-agent operating
+communication. Slack likely fits the future office better, but adding it before
+truth-grounded conversation works would risk creating another noisy inbox.
+
+## Consequences
+
+- Build `ask_company` locally first.
+- Keep truth in `reports/`, `state/`, `memory/`, and `docs/decisions/`.
+- Do not make Slack the source of truth.
+- Do not wire Slack until the Chief of Staff spine can answer common company
+  questions from stored truth.
+
+## Review Trigger
+
+Revisit after the owner can ask 10 common company questions and gets natural,
+grounded answers from local company truth.

--- a/docs/decisions/0002-agent-authority-boundaries.md
+++ b/docs/decisions/0002-agent-authority-boundaries.md
@@ -1,0 +1,42 @@
+# Decision 0002: Agent Authority Boundaries
+
+Date: 2026-05-09
+
+## Decision
+
+Every agent action uses one authority category:
+
+- Auto: agent executes and reports after the fact.
+- Approve: agent proposes; owner approves once; agent executes.
+- Guardrail: agent can block, but cannot approve.
+
+## Default Boundaries
+
+- Trading action: Guardrail or Approve, never fully Auto.
+- Strategy promotion: Guardrail.
+- Publishing and external communication: Approve.
+- Spend, contracts, credentials, and business commitments: Approve or
+  Guardrail.
+- Legal/tax-sensitive work: Approve or Guardrail.
+- Monitoring, internal summaries, and local report generation: Auto.
+- Support routine replies: Approve until quality is proven.
+
+## Rationale
+
+The future company should feel manned, but it must not silently cross dangerous
+business boundaries. Agents should move routine internal work while preserving
+owner control over consequential actions.
+
+## Consequences
+
+- Risk Officer can block but cannot approve.
+- Chief of Staff can route and recommend but cannot approve for the owner.
+- Editorial can draft but cannot publish.
+- Engineering/Ops can prepare and test but cannot deploy production without
+  approval.
+- Quant Ops can block readiness but cannot authorize live trading.
+
+## Review Trigger
+
+Revisit when an agent workflow repeatedly requires owner approval for low-risk
+actions and there is enough quality evidence to consider a narrower Auto lane.

--- a/docs/decisions/_pending/missing-persona-scope-map.md
+++ b/docs/decisions/_pending/missing-persona-scope-map.md
@@ -1,0 +1,27 @@
+# Pending Decision: Missing Persona Scope Map Contract
+
+Date: 2026-05-09
+
+## Context
+
+The overnight build prompt said to read `docs/personas/persona-scope-map.md`
+first because it is the contract. That file did not exist at build start.
+
+## Conservative Action Taken
+
+Created a v0 scope map from the already-approved architecture:
+
+- Personas are conversational entry points to structured skills underneath.
+- Default opening responses are deterministic queries against `state/` and
+  `reports/`.
+- Model-assisted conversation is allowed only for follow-up after deterministic
+  state has been retrieved and rendered.
+- Telegram is demoted to pager/fallback rail; the operating room should become
+  the primary employee-feeling surface.
+
+## Owner Input Needed
+
+Confirm whether this v0 scope map is the contract or whether any persona,
+authority, or default opening should change before the operating room MVP moves
+from scaffold to active workflow.
+

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,30 @@
+# Decision: <Title>
+
+Date: YYYY-MM-DD
+Status: proposed | accepted | rejected | superseded
+Owner: <Owner or persona>
+
+## Context
+
+What prompted the decision?
+
+## Decision
+
+What was decided?
+
+## Rationale
+
+Why is this the right move now?
+
+## Consequences
+
+What changes because of this decision?
+
+## Evidence
+
+- `<path/to/source>`
+
+## Follow-Up
+
+- [ ] Action, owner, due date
+

--- a/docs/personas/chief-of-staff/contract.md
+++ b/docs/personas/chief-of-staff/contract.md
@@ -1,0 +1,46 @@
+# Chief of Staff Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Make the company legible to the owner and route attention.
+
+## Default Opening
+
+"What needs me today?"
+
+This opening must be deterministic. It reads stored company state and renders a
+plain-English answer without a model call.
+
+## Deterministic Sources
+
+- `state/board_approval_decisions.json`
+- `reports/skills/*/latest.json`
+- `reports/phase3_holding_latest.json`
+- `reports/skills/portfolio-retro-weekly/latest.json`
+
+## Allowed Skills
+
+- `risk-aggregate-daily`
+- `portfolio-retro-weekly`
+- `ask_company`
+
+## Authority
+
+Approve. Can summarize, route, and recommend. Cannot approve for the owner.
+
+## Escalates
+
+- Missing or stale truth.
+- Cross-persona disagreement.
+- Owner approvals.
+- RED/BLOCKED items.
+- Approved work waiting for execution follow-through.
+
+## Follow-Up Boundary
+
+Follow-up conversation may be model-assisted only after deterministic state has
+been retrieved and included as context.
+

--- a/docs/personas/editorial-lead/contract.md
+++ b/docs/personas/editorial-lead/contract.md
@@ -1,0 +1,43 @@
+# Editorial Lead Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Convert briefs and evidence into approval-gated content work.
+
+## Default Opening
+
+"What is in the content queue?"
+
+This opening must be deterministic. It reads content state and draft artifacts
+without a model call.
+
+## Deterministic Sources
+
+- Content Studio state and reports where available.
+- `reports/skills/content-brief-to-draft/latest.json`
+- `reports/skills/analytics-weekly/latest.json`
+
+## Allowed Skills
+
+- `content-brief-to-draft`
+- `analytics-weekly`
+- `seo-review`
+
+## Authority
+
+Approve. Can draft and recommend. Cannot publish.
+
+## Escalates
+
+- Publish decisions.
+- Brand/legal risk.
+- Claims requiring sourcing.
+- Any external communication.
+
+## Follow-Up Boundary
+
+Follow-up can refine briefs or draft plans only from supplied or stored context.
+

--- a/docs/personas/engineering-ops/contract.md
+++ b/docs/personas/engineering-ops/contract.md
@@ -1,0 +1,46 @@
+# Engineering/Ops Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Keep the operating layer reliable and visible.
+
+## Default Opening
+
+"What is broken or at risk operationally?"
+
+This opening must be deterministic. It reads local reports, logs, and build
+records without a model call.
+
+## Deterministic Sources
+
+- `reports/daily_brief_latest.json`
+- `reports/phase2_divisions_latest.json`
+- `reports/phase3_holding_latest.json`
+- `reports/skills/*/latest.json`
+- `docs/build-logs/`
+
+## Allowed Skills
+
+- `pre-deploy-checklist`
+- `infra-cost-review`
+- `portfolio-retro-weekly`
+
+## Authority
+
+Approve for local operating-layer recommendations. Guardrail for deploy,
+production, credentials, CI/CD, cloud, Docker, SSH, or server changes.
+
+## Escalates
+
+- Deploy, rollback, production, credential, CI/CD, cloud, Docker, SSH, or server
+  changes.
+- Test/build failures that block merge.
+
+## Follow-Up Boundary
+
+Follow-up can propose local fixes. It must not touch protected property folders
+without explicit approval.
+

--- a/docs/personas/finance-admin/contract.md
+++ b/docs/personas/finance-admin/contract.md
@@ -1,0 +1,38 @@
+# Finance/Admin Persona Contract
+
+Status: deferred
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Monitor cash, costs, subscriptions, close tasks, compliance, and admin signals
+once reliable sources exist.
+
+## Deferral Reason
+
+Reliable cash, cost, subscription, revenue, and accounting feeds are not yet
+wired. This persona should not become active until its default opening can read
+real financial sources deterministically.
+
+## Candidate Default Opening
+
+"What changed financially?"
+
+This opening is not active.
+
+## Candidate Skills
+
+- `monthly-close-prep`
+- `infra-cost-review`
+- `compliance-monitor`
+- `skill-perf-review`
+
+## Authority
+
+Guardrail for spend, compliance, tax, credentials, vendor, and payment changes.
+
+## Activation Gate
+
+Activate only after deterministic sources exist for at least costs, revenue, and
+cash-relevant obligations.
+

--- a/docs/personas/growth-lead/contract.md
+++ b/docs/personas/growth-lead/contract.md
@@ -1,0 +1,43 @@
+# Growth Lead Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Make website growth legible and turn evidence into weekly actions.
+
+## Default Opening
+
+"What changed in growth?"
+
+This opening must be deterministic. It reads website reports and analytics
+artifacts without a model call.
+
+## Deterministic Sources
+
+- `reports/phase2_divisions_latest.json`
+- `reports/skills/analytics-weekly/latest.json`
+- `reports/skills/portfolio-retro-weekly/latest.json`
+
+## Allowed Skills
+
+- `analytics-weekly`
+- `risk-aggregate-daily`
+- `portfolio-retro-weekly`
+
+## Authority
+
+Auto for digest/reporting. Approve for experiments or external changes.
+
+## Escalates
+
+- Missing analytics source.
+- Traffic or revenue anomaly.
+- Any publishing, external, or production-impacting action.
+
+## Follow-Up Boundary
+
+Follow-up can suggest options from evidence. It cannot invent analytics metrics
+or change property files.
+

--- a/docs/personas/persona-scope-map.md
+++ b/docs/personas/persona-scope-map.md
@@ -1,0 +1,203 @@
+# Persona Scope Map
+
+Date: 2026-05-09
+Status: v0 contract pending owner review
+
+## Architectural Rule
+
+Personas are conversational entry points to deterministic skills and durable
+truth records. They are not unconstrained generalist agents.
+
+Every persona response starts with a deterministic truth packet built from
+`state/`, `reports/`, `reports/skills/`, `docs/decisions/`, and approved memory
+records. The truth packet must not call a model. Model-assisted conversation may
+happen only after the packet exists, and the model may only verbalize packet
+contents.
+
+## Surfaces
+
+| Flow | Surface | Rule |
+|---|---|---|
+| Digest | Operating room Today view | Page first, chat follow-up second |
+| Alert | Telegram pager or future push rail | High-signal only |
+| Background | `reports/`, `state/`, `memory/`, `docs/decisions/` | Not pushed by default |
+| Persona conversation | Operating room Personas view | Deterministic truth packet, grounded verbalizer |
+
+## Active Personas
+
+### Chief of Staff
+
+Purpose: make the company legible to the owner and route attention.
+
+Default opening: "What needs me today?"
+
+Deterministic query:
+
+- Pending approvals from `state/board_approval_decisions.json`.
+- RED/BLOCKED latest skill outputs from `reports/skills/*/latest.json`.
+- Approved work awaiting execution from board/work state.
+- Latest holdco status from `reports/phase3_holding_latest.json`.
+- Latest portfolio retro from `reports/skills/portfolio-retro-weekly/latest.json`.
+
+Allowed skills:
+
+- `risk-aggregate-daily`
+- `portfolio-retro-weekly`
+- `ask_company`
+
+Escalates: missing truth, stale truth, cross-persona disagreement, owner
+approval, unresolved RED/BLOCKED items, and execution follow-through gaps.
+
+### Risk Officer
+
+Purpose: protect capital, customers, reputation, and operating stability.
+
+Default opening: "Do you object to anything?"
+
+Deterministic query:
+
+- BLOCKED/RED guardrail outputs from `reports/skills/backtest-review/latest.json`.
+- Trading readiness from `reports/skills/data-quality-daily/latest.json`.
+- Pre-deploy checklist output when available.
+- Pending approvals that mention deploy, trading, spend, publish, credentials,
+  legal, tax, or external communication.
+
+Allowed skills:
+
+- `backtest-review`
+- `pre-deploy-checklist`
+- `risk-aggregate-daily`
+
+Escalates: any missing evidence for a consequential action. Can block; cannot
+approve.
+
+### Quant Ops
+
+Purpose: keep trading data and operational readiness honest.
+
+Default opening: "Are we safe to research or forward-test?"
+
+Deterministic query:
+
+- `reports/skills/data-quality-daily/latest.json`.
+- `reports/skills/backtest-review/latest.json`.
+- Broker reconcile output when available.
+- MT5 evidence artifacts only through existing reports or skill wrappers.
+
+Allowed skills:
+
+- `data-quality-daily`
+- `backtest-review`
+- `broker-reconcile`
+
+Escalates: stale data, missing vendor checks, missing broker/blotter sources,
+or any strategy trying to advance without guardrail artifacts.
+
+### Growth Lead
+
+Purpose: make website growth legible and turn evidence into weekly actions.
+
+Default opening: "What changed in growth?"
+
+Deterministic query:
+
+- Latest website division report from `reports/phase2_divisions_latest.json`.
+- Analytics weekly output when available.
+- Portfolio retro open issues related to websites, growth, traffic, or content.
+
+Allowed skills:
+
+- `analytics-weekly`
+- `risk-aggregate-daily`
+- `portfolio-retro-weekly`
+
+Escalates: missing analytics source, traffic/revenue anomaly, or proposed
+external/publishing action requiring approval.
+
+### Editorial Lead
+
+Purpose: convert briefs and evidence into approval-gated content work.
+
+Default opening: "What is in the content queue?"
+
+Deterministic query:
+
+- Content Studio state and reports where available.
+- Content brief-to-draft output when available.
+- Analytics weekly opportunities when available.
+
+Allowed skills:
+
+- `content-brief-to-draft`
+- `analytics-weekly`
+- `seo-review`
+
+Escalates: publish decisions, brand/legal risk, claims requiring sourcing, and
+any external communication.
+
+### Engineering/Ops
+
+Purpose: keep the operating layer reliable and visible.
+
+Default opening: "What is broken or at risk operationally?"
+
+Deterministic query:
+
+- Latest daily brief and phase reports.
+- Recent generated skill artifacts.
+- Local build/test status recorded in build logs.
+- Incident or deploy readiness artifacts when available.
+
+Allowed skills:
+
+- `pre-deploy-checklist`
+- `infra-cost-review`
+- `portfolio-retro-weekly`
+
+Escalates: deploy, rollback, production, credential, CI/CD, cloud, Docker, SSH,
+or server changes.
+
+### Support Lead
+
+Purpose: triage customer/support input once a real source exists.
+
+Default opening: "What is happening in support?"
+
+Deterministic query:
+
+- `reports/skills/support-triage/latest.json`.
+- Local `state/support_tickets.json` only if it exists.
+
+Allowed skills:
+
+- `support-triage`
+
+Escalates: missing support source, billing/refund/legal/account issues, and any
+reply-send action until explicitly promoted.
+
+### Finance/Admin
+
+Status: deferred.
+
+Reason: reliable cash, cost, subscription, revenue, and accounting feeds are
+not yet wired. Finance/Admin should not become an active persona until its
+deterministic opening can read real financial sources.
+
+Candidate future skills:
+
+- `monthly-close-prep`
+- `infra-cost-review`
+- `compliance-monitor`
+- `skill-perf-review`
+
+## Discipline Checks
+
+- If a persona cannot answer from deterministic truth, it says what is missing.
+- If a user asks a follow-up, the persona may use a model only with retrieved
+  state in context.
+- If NanoClaw is used, it acts only as a verbalizer over the truth packet. It
+  cannot read files, call tools, write state, approve, block, or execute.
+- If a persona proposes action, the action must map to Auto, Approve, or
+  Guardrail authority.
+- If a persona needs a skill that does not exist, create a DRAFT Shadow skill
+  spec, not a fake runtime.

--- a/docs/personas/quant-ops/contract.md
+++ b/docs/personas/quant-ops/contract.md
@@ -1,0 +1,45 @@
+# Quant Ops Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Keep trading data and operational readiness honest.
+
+## Default Opening
+
+"Are we safe to research or forward-test?"
+
+This opening must be deterministic. It reads data-quality and backtest-review
+artifacts without a model call.
+
+## Deterministic Sources
+
+- `reports/skills/data-quality-daily/latest.json`
+- `reports/skills/backtest-review/latest.json`
+- Broker reconcile output when available.
+- Existing MT5 evidence only through reports or skill wrappers.
+
+## Allowed Skills
+
+- `data-quality-daily`
+- `backtest-review`
+- `broker-reconcile`
+
+## Authority
+
+Guardrail. Can block readiness. Cannot approve strategy promotion or execution.
+
+## Escalates
+
+- Stale data.
+- Missing vendor checks.
+- Missing broker/blotter sources.
+- Any strategy advancing without guardrail artifacts.
+
+## Follow-Up Boundary
+
+Follow-up can explain evidence gaps and next checks. It must not inspect or
+modify protected trading property code.
+

--- a/docs/personas/risk-officer/contract.md
+++ b/docs/personas/risk-officer/contract.md
@@ -1,0 +1,44 @@
+# Risk Officer Persona Contract
+
+Status: active
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Protect capital, customers, reputation, and operating stability.
+
+## Default Opening
+
+"Do you object to anything?"
+
+This opening must be deterministic. It reads guardrail outputs and approval
+state without a model call.
+
+## Deterministic Sources
+
+- `reports/skills/backtest-review/latest.json`
+- `reports/skills/data-quality-daily/latest.json`
+- `reports/skills/pre-deploy-checklist/latest.json`
+- `state/board_approval_decisions.json`
+
+## Allowed Skills
+
+- `backtest-review`
+- `pre-deploy-checklist`
+- `risk-aggregate-daily`
+
+## Authority
+
+Guardrail. Can block. Cannot approve.
+
+## Escalates
+
+- Missing evidence for consequential actions.
+- Trading, deploy, spend, publish, credentials, legal, tax, or external
+  communication risk.
+
+## Follow-Up Boundary
+
+Follow-up conversation may explain a block, but it cannot soften or override the
+stored guardrail state.
+

--- a/docs/personas/support-lead/contract.md
+++ b/docs/personas/support-lead/contract.md
@@ -1,0 +1,40 @@
+# Support Lead Persona Contract
+
+Status: active only when a support source exists
+Source: `docs/personas/persona-scope-map.md`
+
+## Purpose
+
+Triage customer/support input once a real source exists.
+
+## Default Opening
+
+"What is happening in support?"
+
+This opening must be deterministic. It reads support-triage artifacts and local
+ticket state without a model call.
+
+## Deterministic Sources
+
+- `reports/skills/support-triage/latest.json`
+- `state/support_tickets.json` if present
+
+## Allowed Skills
+
+- `support-triage`
+
+## Authority
+
+Approve. Can classify and draft. Cannot send replies until explicitly promoted.
+
+## Escalates
+
+- Missing support source.
+- Billing, refund, legal, account, privacy, or reputational issues.
+- Any external reply-send action.
+
+## Follow-Up Boundary
+
+Follow-up can explain triage and draft replies from ticket text. It must not
+expose customer data outside approved systems.
+

--- a/docs/retrofit-plan-analysis.md
+++ b/docs/retrofit-plan-analysis.md
@@ -1,0 +1,176 @@
+# Retrofit Plan Analysis
+
+Date: 2026-05-09
+
+This analysis validates the proposed 9-skill retrofit against the current `ai-holding-company` folder. I treated first-party docs, configs, scripts, crew specs, tests, and nested project runbooks as relevant. I treated virtualenvs, `.next`, caches, generated worktrees, raw logs, and generated reports as structure/cleanup signal rather than product source.
+
+## Executive Synthesis
+
+The repo already has a real operating shell: Telegram is the owner interface, `scripts/tool_router.py` is the command router, `scripts/phase2_crews.py` and `scripts/phase3_holding.py` produce division and CEO briefs, `scripts/company_loop.py` records file-first operating loops, `scripts/content_studio.py` handles CEO-gated drafts, `scripts/weekly_retro.py` runs a recurring retro, and `scripts/local_vector_memory.py` provides local vector memory.
+
+The retrofit should not introduce a parallel agent platform. It should add a thin, opinionated skill layer on top of the existing command/router/report/state shape. The main mismatch is naming and packaging: the plan assumes slash-command skills, but the project currently uses Telegram bot commands, CLI subcommands, crew YAML, markdown runbooks, and local state files. Since Telegram is the sole automation interface, runtime command names should use Telegram-safe underscores, while markdown skill files can keep the plan's hyphenated names.
+
+## Fits Cleanly
+
+- Risk aggregate daily: `scripts/phase3_holding.py`, `crews/holding_ceo.yaml`, `config/targets.yaml`, `reports/phase3_holding_latest.*`, `scripts/aiogram_bridge.py` `/brief`, `/board`, `/approvals`.
+  Current autonomy: mostly Auto for read-only brief generation; Approve for board items through `/approve`, `/deny`, `/assign`, `/start`, `/done`. This is the closest existing match to `/risk-aggregate-daily`.
+
+- Portfolio retro weekly: `scripts/weekly_retro.py`, `tests/test_weekly_retro.py`, `state/retro_state.json`, `reports/retros/`.
+  Current autonomy: Auto. It already has weekly scheduling/catch-up logic and Telegram send behavior, but only summarizes `state/events.db`; it does not yet pull every other skill output, commits, deploys, incidents, and decisions as the proposed skill requires.
+
+- Content brief to draft: `scripts/content_studio.py`, `crews/content_studio.yaml`, `README_TELEGRAM_BRIDGE.md`, Telegram `/content`, `/content_status`, `/content_approve`, `/content_deny`, `artifacts/content_studio_drafts.jsonl`.
+  Current autonomy: Approve for publication; Auto for draft creation once a brief is submitted. It already enforces `PENDING_CEO_APPROVAL` and blocks auto-publish.
+
+- Holding-company approvals and guardrails: `scripts/aiogram_bridge.py`, `state/board_approval_decisions.json`, `docs/templates/approval_request.md`, `docs/LOOP_OPERATING_MODEL.md`, `kernel/work_items.py`.
+  Current autonomy: Approve. This is not one of the 9 skills, but it is the substrate all 9 should reuse.
+
+- Memory layer: `scripts/local_vector_memory.py`, `memory/`, `scripts/tool_router.py log_direction`, `scripts/tool_router.py memory_search`, Telegram `/memory`.
+  Current autonomy: Auto for saving/searching local notes. This fits the gstack/g-brain intent, but it is a local JSONL/Ollama embedding store, not a full markdown skill memory system.
+
+- Trading research foundation: `mt5-agentic-desk/tools/backtest_engine.py`, `mt5-agentic-desk/tools/backtest_tool.py`, `mt5-agentic-desk/tools/strategy_qualification_report.py`, `mt5-agentic-desk/tools/daily_operator_workflow.py`, `mt5-agentic-desk/docs/evidence-build-checklist-2026-05-04.md`, `mt5-agentic-desk/docs/adversarial-review-2026-05-04.md`.
+  Current autonomy: Guardrail/Approve. The MT5 desk already separates research from trading and blocks active promotion without evidence. It is not yet exposed as a parent-level `/backtest-review` skill.
+
+## Needs Adapting
+
+- `/backtest-review` overlaps with MT5 adversarial review and qualification reports.
+  Proposed change: create a parent-level skill spec and command wrapper that reads MT5 research/backtest artifacts and produces a standardized adversarial review record under `reports/skills/backtest-review/`. Do not move backtesting logic into the parent repo. Add pass-rate and changed-after-review counters so the `<40% pass unchanged` success metric is trackable.
+  Candidate files: add `docs/skills/backtest-review.md`, add `scripts/skill_backtest_review.py`, wire `tool_router.py backtest_review`, optionally wire Telegram `/backtest_review`.
+  Target autonomy: Guardrail.
+
+- `/data-quality-daily` overlaps with `scripts/monitoring.py`, `scripts/phase2_crews.py` trading scorecards, and MT5 runtime/data health checks.
+  Proposed change: adapt it into a pre-market data integrity skill that reads MT5 feed freshness, bar gaps, strategy library freshness, Polymarket remote sync age, and current config thresholds. The proposed vendor cross-check/corporate-actions scope does not fit current FX/Polymarket reality; make those explicit N/A checks until real equities/data vendors exist.
+  Candidate files: add `docs/skills/data-quality-daily.md`, add `scripts/skill_data_quality_daily.py`, extend `config/targets.yaml` with only proven thresholds if needed.
+  Target autonomy: Guardrail.
+
+- `/content-brief-to-draft` overlaps with two systems: lightweight Content Studio in parent repo and the richer `free-traderhub-research-team` weekly crew.
+  Proposed change: keep parent `scripts/content_studio.py` as the skill runtime for brief-in/draft-out. Treat `free-traderhub-research-team` as a weekly research source feeding briefs, not as the runtime command. Rename surface from generic `/content` to `/content_brief` if you want the skill name to be explicit, but keep `/content` as an alias for muscle memory.
+  Target autonomy: Approve for publication; Auto for draft creation.
+
+- `/analytics-weekly` overlaps with `scripts/fth_monitor.py`, `free-traderhub-research-team/run_weekly.py`, `docs/templates/weekly_business_scorecard.md`, and Phase 3 property department briefs.
+  Proposed change: make it a weekly website analytics digest skill focused on FTH first: Umami/manual KPIs, GSC export summary, content production, email list, affiliate clicks/revenue, anomalies, and next decisions. Do not build generalized analytics until another website has real metrics.
+  Candidate files: add `docs/skills/analytics-weekly.md`, add `scripts/skill_analytics_weekly.py`, have it read `state/property_metrics/freetraderhub/shared.json` and `free-traderhub-research-team/reports/*/00_executive_brief.md`.
+  Target autonomy: Auto.
+
+- `/portfolio-retro-weekly` fits `scripts/weekly_retro.py` but is too narrow.
+  Proposed change: extend the retro collector to include latest skill reports from `reports/skills/`, board approval decisions, content draft decisions, company loops, GitHub issue cadence, and recent git commits/deploy notes where locally available. Keep the output short.
+  Candidate files: edit `scripts/weekly_retro.py`, `tests/test_weekly_retro.py`, add `docs/skills/portfolio-retro-weekly.md`.
+  Target autonomy: Auto.
+
+- `/risk-aggregate-daily` fits Phase 3 but needs a skill identity.
+  Proposed change: add a skill spec that defines the one-page cross-portfolio brief contract and maps it to `tool_router.py run_holding --mode heartbeat --force` plus board-pack escalation when RED/AMBER exists. Do not duplicate `phase3_holding.py`.
+  Candidate files: add `docs/skills/risk-aggregate-daily.md`; optionally add a `tool_router.py risk_aggregate_daily` alias to existing `run_holding`.
+  Target autonomy: Auto for the brief; Approve for actions created from it.
+
+- `/pre-deploy-checklist` overlaps with website QA checklists, Developer Tool approvals, Polymarket live checklist, and MT5 promotion gates, but there is no single strategy-go-live guardrail.
+  Proposed change: scope it specifically to trading strategy deployment, not generic code deploy. It should read MT5 strategy qualification, paper/watchlist evidence, data-quality status, broker/recon status when available, and return BLOCK/PASS-FOR-HUMAN-APPROVAL. It must never approve.
+  Candidate files: add `docs/skills/pre-deploy-checklist.md`, add `scripts/skill_pre_deploy_checklist.py`.
+  Target autonomy: Guardrail.
+
+## Missing
+
+Build priority given current state:
+
+1. `/backtest-review` - P0. Most of the raw material exists in MT5; parent-level skill packaging and metrics are missing.
+2. `/data-quality-daily` - P0. Current monitoring is health/freshness, not pre-market data integrity. This is the largest P0 trading reliability gap.
+3. `/support-triage` - P0. No support inbox, ticket model, triage classifier, draft reply workflow, CSAT, or response-time tracking exists.
+4. `/risk-aggregate-daily` skill wrapper - P0. Runtime exists; explicit skill contract, autonomy tag, and success metrics do not.
+5. `/broker-reconcile` - P1. No internal blotter/broker/clearing three-way reconciliation model exists. Current trading logs are not a reconciliation ledger.
+6. `/pre-deploy-checklist` - P1. Strategy promotion gates exist inside MT5, but no parent-level guardrail command exists.
+7. `/analytics-weekly` - P1. Raw FTH metric and GSC/research pieces exist; the weekly anomaly digest does not.
+8. `/content-brief-to-draft` skill wrapper - P1. Runtime exists; explicit skill contract and KPI tracking need tightening.
+9. `/portfolio-retro-weekly` enhancement - P1. Scheduler exists; richer inputs and decision logging need adding.
+
+## Redundant Or Out Of Scope
+
+- `openclaw/`, `docker-compose.yml`, OpenClaw sections in `README_PHASE1.md`, `README_PHASE2.md`, `PHASE-1-GUIDE.md`, and `heartbeat.yaml`.
+  Recommendation: archive or mark hard-deprecated in one place. Current rules prohibit OpenClaw, and these files can mislead the retrofit.
+
+- `tools/system_status.py`.
+  Recommendation: replace or archive after adding a Telegram/Ollama-only status check. It actively checks Docker/OpenClaw and conflicts with R11.
+
+- `.claude/worktrees/*` and nested `.claude/worktrees` under projects.
+  Recommendation: keep out of synthesis and consider cleanup/archive after confirming no active work is needed. They are cloned workspaces, not operating company source.
+
+- `projects/ccba-prep-tool/`.
+  Recommendation: out of scope for this 9-skill plan unless it becomes a managed website property in `config/projects.yaml`. It is a separate Next.js product with its own `.env.local`, Supabase, and worktrees; do not fold it into the trading/websites retrofit yet.
+
+- Root-level product folders: `finance_web_page/`, `free-utility-tools/`, `free-traderhub-research-team/`, `mt5-agentic-desk/`, `polymarket-bot/`.
+  Recommendation: not delete, but structurally they belong under `projects/` long term. Several docs already recommend this. Move only as an explicit migration because some are gitlinks/nested repos and config paths depend on current locations.
+
+- Legacy root docs with stale paths or old snapshots, especially `RESUME.md` drift notes and old OpenClaw runbooks.
+  Recommendation: keep for history, but create a `docs/archive/` bucket later so current operating instructions remain unambiguous.
+
+## Naming And Structure Conflicts
+
+- Telegram bot commands cannot safely use hyphens. The plan's names are good markdown skill filenames, but runtime commands should use underscores:
+  - `/backtest_review`
+  - `/data_quality_daily`
+  - `/broker_reconcile`
+  - `/pre_deploy_checklist`
+  - `/support_triage`
+  - `/content_brief_to_draft` or existing `/content`
+  - `/analytics_weekly`
+  - `/risk_aggregate_daily` or existing `/brief`
+  - `/portfolio_retro_weekly`
+
+- Existing command style is terse: `/brief`, `/board`, `/content`, `/work`, `/loop`. Better pattern: keep terse production aliases and add explicit skill aliases for clarity.
+
+- There is no project `skills/` folder, no local `SKILL.md` project skills, and `.gstack/` only contains `no-test-bootstrap`. The existing "skill" equivalents are `crews/*.yaml`, `docs/*.md`, `scripts/tool_router.py` subcommands, Telegram handlers, and state/report files.
+
+- `CLAUDE.md` mentions external slash skills like `/office-hours`, `/autoplan`, `/investigate`, `/review`, `/ship`, but those are not present in the project tree. Treat them as editor/tooling guidance, not as implemented project skills.
+
+- Current docs explicitly warn not to create separate `agents/prompts/configs/skills` folders unless needed. For this retrofit, the least-disruptive structure is:
+  - `docs/skills/<hyphenated-skill-name>.md` for skill contracts.
+  - `scripts/skill_<underscore_name>.py` only when a real runtime is needed.
+  - `scripts/tool_router.py <underscore_name>` as the CLI surface.
+  - Telegram `/underscore_name` aliases only after CLI behavior is proven.
+
+## Structural Assumptions That Do Not Match
+
+- The plan assumes a flat slash-command skills layer. The repo currently has a Telegram-first operating layer plus CLI/router commands, not a flat skill system.
+
+- The plan assumes all skills need new builds. Several are already partially implemented as operating routines: Content Studio, Phase 3 daily risk aggregation, weekly retro, memory, approval state, and MT5 evidence gates.
+
+- The plan assumes trading strategy generation is hybrid. The MT5 desk already follows that principle: humans can suggest hypotheses, Research Mode backtests/promotes, Trading Mode only considers validated active library strategies.
+
+- The plan assumes a general websites vertical. Current live operating focus is FreeTraderHub; FreeGhostTools is present but parked/maintenance, and CCBA is not wired into the holding-company config.
+
+- The plan assumes memory/g-brain is missing. Local vector memory is present, but it is underused and not automatically attached to every skill output.
+
+- The rollout says support triage goes live in weeks 3-4, but no support channel exists. That is only realistic if the first two weeks also define the ticket source and support state shape.
+
+- The plan says broker reconciliation is P1. In this repo, it is lower practical leverage than data quality and pre-deploy guardrails until there is a canonical internal blotter and broker/clearing export.
+
+## Recommended First-Week Action List
+
+1. Create `docs/skills/README.md` documenting the project skill contract: owner, vertical, autonomy tag, inputs, outputs, success metrics, state/report paths, Telegram alias, and "never" rules.
+
+2. Create `docs/skills/risk-aggregate-daily.md` mapping the skill to `python scripts/tool_router.py run_holding --mode heartbeat --force`, `reports/phase3_holding_latest.*`, and board approval escalation.
+
+3. Create `docs/skills/backtest-review.md` defining the adversarial backtest review checklist, required MT5 artifacts, pass/block outputs, and metrics: pass unchanged rate, false-positive tracking, and reviewer time saved.
+
+4. Create `docs/skills/data-quality-daily.md` defining the pre-market integrity checklist for current assets: MT5 bar freshness/gaps, strategy library freshness, Polymarket remote sync, report age, and explicit N/A placeholders for corp actions/vendor cross-checks.
+
+5. Create `docs/skills/content-brief-to-draft.md` mapping the skill to existing `/content` and `scripts/content_studio.py`, with publication remaining CEO-gated.
+
+6. Create `docs/skills/support-triage.md` as a shadow-mode spec only. Include the missing prerequisite: decide the ticket source before runtime build.
+
+7. Create `docs/skills/analytics-weekly.md` mapping the first version to FreeTraderHub metrics, GSC/research reports, content output, email list, affiliate progress, and anomaly surfacing.
+
+8. Create `docs/skills/portfolio-retro-weekly.md` mapping current `scripts/weekly_retro.py` behavior and listing required added sources: skill outputs, board decisions, content decisions, loops, commits, deploys, and incidents.
+
+9. Create `docs/skills/pre-deploy-checklist.md` and `docs/skills/broker-reconcile.md` as P1 contracts only. Do not build runtime until P0 shadow reports are stable.
+
+10. Edit `README_TELEGRAM_BRIDGE.md` to add a "Planned skill aliases" section with underscore-safe Telegram command names, clearly marked not implemented until wired.
+
+11. Edit `docs/STRUCTURE_MAP.md` to add `docs/skills/` as the contract layer while keeping `crews/`, `scripts/`, `reports/`, `state/`, and `memory/` as runtime locations.
+
+12. Edit `PLAN.md` forward-focus section to align the 90-day rollout with existing Phase 2/3/Content/Retro systems, and to state that P0 shadow mode writes reports only.
+
+13. After docs are reviewed, implement only two P0 runtime aliases first: `risk_aggregate_daily` as a wrapper/alias to existing Phase 3, and `backtest_review` as a report wrapper over MT5 artifacts.
+
+14. Run documentation review against AGENTS Code Review Gate: markdown clarity, no stale OpenClaw routing, no secret paths beyond existing documented local paths, and no new network or cloud assumptions.
+
+## Bottom Line
+
+The 9-skill plan fits the direction of the project, but it should be implemented as a thin skill-contract layer over the existing Telegram/CLI/report/state operating system. The cleanest first move is not a new framework; it is to standardize the nine skills as markdown contracts, tag autonomy explicitly, and wire only the P0 runtime gaps that already have data behind them.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,56 @@
+# Skill Contracts
+
+Skill contracts define repeatable operating workflows for the agent-manned SaaS
+company. They are not a separate runtime framework.
+
+Runtime should use existing rails first:
+
+- `scripts/tool_router.py`
+- `scripts/aiogram_bridge.py`
+- `reports/`
+- `state/`
+- `memory/`
+- `docs/decisions/`
+
+## Contract Fields
+
+Each skill should define:
+
+- Name.
+- Owner agent.
+- Vertical.
+- Autonomy: Auto, Approve, or Guardrail.
+- Inputs.
+- Outputs.
+- Report/state paths.
+- Natural owner-facing behavior.
+- Structured record fields.
+- Success metrics.
+- Never rules.
+
+## Naming
+
+Markdown filenames can use hyphens, for example:
+
+```text
+docs/skills/risk-aggregate-daily.md
+```
+
+Runtime commands should use underscores because Telegram commands are safer that
+way:
+
+```text
+risk_aggregate_daily
+```
+
+## First Skills To Formalize
+
+- `risk-aggregate-daily`
+- `backtest-review`
+- `data-quality-daily`
+- `content-brief-to-draft`
+- `analytics-weekly`
+- `portfolio-retro-weekly`
+- `support-triage`
+- `pre-deploy-checklist`
+- `broker-reconcile`

--- a/docs/skills/analytics-weekly.md
+++ b/docs/skills/analytics-weekly.md
@@ -1,0 +1,51 @@
+# analytics-weekly
+
+## Owner Agent
+
+Growth Lead.
+
+## Vertical
+
+Websites.
+
+## Autonomy
+
+Auto for internal digest. Approve for external or spend actions.
+
+## Purpose
+
+Create a weekly website analytics digest that surfaces anomalies, explains what
+changed, and recommends evidence-backed growth decisions.
+
+## First Scope
+
+FreeTraderHub first. Do not generalize to every property until another property
+has reliable metrics.
+
+## Inputs
+
+- `state/property_metrics/freetraderhub/shared.json`
+- `state/property_metric_feed.json`
+- `reports/phase3_holding_latest.*`
+- FreeTraderHub research reports.
+- Content output and draft state.
+
+## Outputs
+
+- Weekly digest in `reports/skills/analytics-weekly/`.
+- Anomaly list.
+- Recommended growth decisions.
+- Editorial or Engineering/Ops handoffs.
+
+## Success Metrics
+
+- Anomalies surfaced versus baseline.
+- Decisions per digest.
+- Owner no longer has to manually inspect every dashboard.
+
+## Never
+
+- Never guess missing dashboard values.
+- Never call external analytics APIs without explicit approval and credentials
+  already configured safely.
+- Never recommend spend without approval.

--- a/docs/skills/ask-company.md
+++ b/docs/skills/ask-company.md
@@ -1,0 +1,35 @@
+---
+status: DRAFT
+owner: Chief of Staff
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# ask-company
+
+## Purpose
+
+Answer owner questions from deterministic company truth before any follow-up
+conversation.
+
+## Inputs
+
+- `reports/phase3_holding_latest.json`
+- `reports/phase2_divisions_latest.json`
+- `reports/daily_brief_latest.json`
+- `state/board_approval_decisions.json`
+- `reports/skills/*/latest.json`
+- `memory/` for context only
+
+## Outputs
+
+- Natural owner-facing answer.
+- Owner need classification.
+- Source list when requested or consequential.
+
+## Shadow Rule
+
+Default openings must not call a model. Follow-up conversation may use a model
+only after deterministic state has been retrieved and rendered.
+

--- a/docs/skills/backtest-review.md
+++ b/docs/skills/backtest-review.md
@@ -1,0 +1,61 @@
+# backtest-review
+
+## Owner Agent
+
+Quant Research Lead, reviewed by Risk Officer.
+
+## Vertical
+
+Trading.
+
+## Autonomy
+
+Guardrail.
+
+## Purpose
+
+Adversarially review every backtest before forward-test. The goal is to reject,
+challenge, or require revision of weak evidence before it becomes operational
+risk.
+
+## Inputs
+
+- MT5 backtest artifacts.
+- Strategy qualification reports.
+- Research hypothesis.
+- Test window and data-quality evidence.
+- Prior strategy decisions from `memory/` or `docs/decisions/`.
+
+## Outputs
+
+- Pass-for-owner-approval, revise, or block.
+- Adversarial objections.
+- Evidence gaps.
+- Required next action.
+- Review record in `reports/skills/backtest-review/`.
+
+## Current Runtime
+
+Run locally through the Telegram/tool router:
+
+```powershell
+python scripts/tool_router.py backtest_review
+```
+
+The runtime reads the latest local MT5 research artifact from
+`mt5-agentic-desk/logs/research/`, the latest trading data-quality artifact
+from `reports/skills/data-quality-daily/latest.json`, and writes timestamped
+plus `latest.*` review records under `reports/skills/backtest-review/`.
+
+## Success Metrics
+
+- Less than 40% of backtests pass unchanged.
+- False-positive rate is trackable.
+- Review time saved versus human peer review.
+- No forward-test without review artifact.
+
+## Never
+
+- Never approve live trading.
+- Never treat a strong backtest as sufficient without data-quality evidence.
+- Never ignore test-window or overfitting concerns.

--- a/docs/skills/broker-reconcile.md
+++ b/docs/skills/broker-reconcile.md
@@ -1,0 +1,49 @@
+# broker-reconcile
+
+## Owner Agent
+
+Quant Ops.
+
+## Vertical
+
+Trading.
+
+## Autonomy
+
+Guardrail.
+
+## Purpose
+
+Run daily three-way reconciliation between internal blotter, broker, and
+clearing/export source once those sources exist.
+
+## Current Status
+
+Spec only. The repo does not yet have a canonical internal blotter, broker
+export, or clearing source.
+
+## Inputs
+
+- Internal blotter.
+- Broker export.
+- Clearing/export source where relevant.
+- Strategy/order identifiers.
+
+## Outputs
+
+- Breaks/day.
+- Break details.
+- MTTR.
+- Block state for trading actions when breaks are unresolved.
+
+## Success Metrics
+
+- Breaks/day.
+- Mean time to resolution.
+- No trading promotion when reconciliation breaks are unresolved.
+
+## Never
+
+- Never hide breaks.
+- Never auto-resolve mismatches.
+- Never treat missing exports as a clean reconciliation.

--- a/docs/skills/compliance-monitor.md
+++ b/docs/skills/compliance-monitor.md
@@ -1,0 +1,32 @@
+---
+status: DRAFT
+owner: Finance/Admin
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# compliance-monitor
+
+## Purpose
+
+Track compliance-sensitive operating changes and surface review needs.
+
+## Inputs
+
+- Decisions and approval logs.
+- Website policy/content changes.
+- Trading scope and strategy promotion artifacts.
+- External counsel/accountant notes when provided.
+
+## Outputs
+
+- Compliance watchlist.
+- Evidence gaps.
+- Escalation memo for owner or external advisor.
+
+## Never
+
+- Never provide legal, tax, or regulatory advice as final authority.
+- Never submit filings or accept legal terms.
+

--- a/docs/skills/content-brief-to-draft.md
+++ b/docs/skills/content-brief-to-draft.md
@@ -1,0 +1,53 @@
+# content-brief-to-draft
+
+## Owner Agent
+
+Editorial Lead.
+
+## Vertical
+
+Websites.
+
+## Autonomy
+
+Approve for publishing. Auto for internal draft creation after a brief exists.
+
+## Purpose
+
+Turn a brief into a useful, brand-consistent, SEO-aware draft while keeping
+publishing owner-gated.
+
+## Current Runtime Mapping
+
+- Existing runtime: `scripts/content_studio.py`
+- Existing CLI: `python scripts/tool_router.py content_create --brief-text "..."`
+- Existing Telegram aliases: `/content`, `/content_status`,
+  `/content_approve`, `/content_deny`
+- Draft state: `artifacts/content_studio_drafts.jsonl`
+
+## Inputs
+
+- Owner or Growth brief.
+- FreeTraderHub research outputs.
+- Brand/SEO guidance.
+- Prior decisions and owner preferences.
+
+## Outputs
+
+- Draft.
+- Draft summary.
+- Approval request for publishing.
+- Revision or denial record.
+
+## Success Metrics
+
+- Editor time per piece reduced.
+- Drafts shipped with fewer major rewrites.
+- No AI prose published without explicit approval.
+
+## Never
+
+- Never publish automatically.
+- Never invent claims, trading advice, revenue claims, or compliance-sensitive
+  statements.
+- Never skip owner approval for external communication.

--- a/docs/skills/data-quality-daily.md
+++ b/docs/skills/data-quality-daily.md
@@ -1,0 +1,45 @@
+# data-quality-daily
+
+## Owner Agent
+
+Quant Ops.
+
+## Vertical
+
+Trading.
+
+## Autonomy
+
+Guardrail.
+
+## Purpose
+
+Check data integrity before trading research, forward-test, or live-readiness
+decisions rely on the data.
+
+## Inputs
+
+- MT5 feed freshness and report artifacts.
+- Missing bar/gap evidence when available.
+- Strategy library freshness.
+- Polymarket sync/report freshness where relevant.
+- `config/targets.yaml`.
+
+## Outputs
+
+- GREEN, AMBER, RED, or BLOCKED readiness result.
+- Data issues and affected symbols/sources.
+- Explicit N/A entries for sources that do not exist yet.
+- Report in `reports/skills/data-quality-daily/`.
+
+## Success Metrics
+
+- Issues caught before they hit live strategies or research promotion.
+- False-positive rate under 10% once enough history exists.
+- Every forward-test decision has current data-quality evidence.
+
+## Never
+
+- Never approve strategy deployment.
+- Never silently skip missing feeds.
+- Never pretend vendor cross-checks or corporate actions exist before they do.

--- a/docs/skills/infra-cost-review.md
+++ b/docs/skills/infra-cost-review.md
@@ -1,0 +1,32 @@
+---
+status: DRAFT
+owner: Engineering/Ops
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# infra-cost-review
+
+## Purpose
+
+Surface infrastructure, subscription, hosting, and tooling cost drift once
+reliable local cost sources exist.
+
+## Inputs
+
+- Local cost exports when available.
+- Hosting/tooling invoices or summaries when available.
+- Property/service mapping.
+
+## Outputs
+
+- Cost anomaly summary.
+- Suggested consolidation or cancellation candidates.
+- Owner approval requests for spend changes.
+
+## Never
+
+- Never cancel, buy, downgrade, or modify services automatically.
+- Never read or expose payment details or credentials.
+

--- a/docs/skills/monthly-close-prep.md
+++ b/docs/skills/monthly-close-prep.md
@@ -1,0 +1,33 @@
+---
+status: DRAFT
+owner: Finance/Admin
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# monthly-close-prep
+
+## Purpose
+
+Prepare a monthly close packet from local financial evidence once reliable
+sources exist.
+
+## Inputs
+
+- Trading P&L summaries.
+- Website revenue summaries.
+- Infra and subscription cost summaries.
+- Bank/accounting exports when approved.
+
+## Outputs
+
+- Close checklist.
+- Missing evidence list.
+- Management-account prep notes.
+
+## Never
+
+- Never file taxes, submit reports, move money, or modify accounting records.
+- Never expose payment details, bank credentials, or tax identifiers.
+

--- a/docs/skills/portfolio-retro-weekly.md
+++ b/docs/skills/portfolio-retro-weekly.md
@@ -1,0 +1,66 @@
+# portfolio-retro-weekly
+
+## Owner Agent
+
+Chief of Staff.
+
+## Vertical
+
+Holdco.
+
+## Autonomy
+
+Auto.
+
+## Purpose
+
+Run a weekly portfolio retro that pulls outputs from agents, commits/deploys
+where locally available, incidents, approvals, decisions, and unresolved issues.
+
+## Current Runtime Mapping
+
+- Skill runtime: `scripts/skill_portfolio_retro_weekly.py`
+- Legacy scheduled runtime: `scripts/weekly_retro.py`
+- Existing state: `state/retro_state.json`
+- Existing reports: `reports/retros/`
+- Skill reports: `reports/skills/portfolio-retro-weekly/`
+
+Run locally through the Telegram/tool router:
+
+```powershell
+python scripts/tool_router.py portfolio_retro_weekly
+```
+
+Telegram command:
+
+```text
+/portfolio_retro_weekly
+```
+
+## Inputs
+
+- `reports/skills/`
+- `reports/phase3_holding_latest.*`
+- Board approval state.
+- Content decisions.
+- Company loops.
+- Local commit/deploy notes where available.
+- Incident notes.
+
+## Outputs
+
+- Weekly retro.
+- Decisions logged.
+- Open issues and owners.
+- Follow-through for the next week.
+
+## Success Metrics
+
+- Weekly consistency.
+- Decisions logged per retro.
+- Repeated unresolved issues become visible.
+
+## Never
+
+- Never turn the retro into a raw log dump.
+- Never lose owner decisions in chat only.

--- a/docs/skills/pre-deploy-checklist.md
+++ b/docs/skills/pre-deploy-checklist.md
@@ -1,0 +1,46 @@
+# pre-deploy-checklist
+
+## Owner Agent
+
+Risk Officer.
+
+## Vertical
+
+Trading.
+
+## Autonomy
+
+Guardrail.
+
+## Purpose
+
+Block unsafe strategy go-live or forward-test promotion. This is a trading
+strategy deployment guardrail, not a generic software deploy checklist.
+
+## Inputs
+
+- Backtest review.
+- Data-quality daily result.
+- Strategy qualification report.
+- Paper/watchlist evidence.
+- Broker/recon status when available.
+- Prior owner decisions.
+
+## Outputs
+
+- BLOCK or PASS-FOR-HUMAN-APPROVAL.
+- Missing evidence.
+- Risk explanation.
+- Required next condition.
+
+## Success Metrics
+
+- No strategy promotion without required evidence.
+- Blocks are specific and resolvable.
+- Risk cannot approve, only block or pass to owner.
+
+## Never
+
+- Never auto-approve.
+- Never approve live trading.
+- Never treat missing evidence as low risk.

--- a/docs/skills/risk-aggregate-daily.md
+++ b/docs/skills/risk-aggregate-daily.md
@@ -1,0 +1,52 @@
+# risk-aggregate-daily
+
+## Owner Agent
+
+Chief of Staff, with Risk Officer input.
+
+## Vertical
+
+Holdco.
+
+## Autonomy
+
+Auto for brief generation. Approve for actions created from the brief.
+
+## Purpose
+
+Produce a one-page daily cross-portfolio risk brief covering trading, websites,
+cost/cash-relevant signals when available, anomalies, and owner decisions.
+
+## Current Runtime Mapping
+
+- Existing source: `scripts/phase3_holding.py`
+- Existing CLI: `python scripts/tool_router.py run_holding --mode heartbeat --force`
+- Future alias: `python scripts/tool_router.py risk_aggregate_daily --force`
+- Latest reports: `reports/phase3_holding_latest.*`
+
+## Inputs
+
+- `reports/daily_brief_latest.*`
+- `reports/phase2_divisions_latest.*`
+- `reports/phase3_holding_latest.*`
+- `state/board_approval_decisions.json`
+- `state/property_metric_feed.json`
+- `memory/`
+
+## Outputs
+
+- Natural CEO-facing brief.
+- Structured sidecar for status, sources, owner needs, and handoffs.
+- Approval items when action requires owner approval.
+
+## Success Metrics
+
+- Less than five minutes to understand the company.
+- At least one useful issue per month surfaced before becoming a problem.
+- No invented status, revenue, trades, approvals, or decisions.
+
+## Never
+
+- Never approve actions for the owner.
+- Never hide missing or stale inputs.
+- Never route around the approval system.

--- a/docs/skills/seo-review.md
+++ b/docs/skills/seo-review.md
@@ -1,0 +1,36 @@
+---
+status: DRAFT
+owner: Editorial Lead
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# seo-review
+
+## Purpose
+
+Review content structure, search intent fit, metadata, internal-link needs, and
+claim risk before publishing.
+
+## Inputs
+
+- Draft content.
+- Target keyword or search intent.
+- Brand voice and editorial rules.
+- Existing content inventory when available.
+
+## Outputs
+
+- Pass, revise, or block recommendation.
+- SEO issues.
+- Metadata suggestions.
+- Internal-link suggestions.
+
+## Never
+
+- Never publish content.
+- Never invent traffic or ranking claims.
+- Never approve legal, financial, or trading-performance claims without source
+  evidence.
+

--- a/docs/skills/skill-perf-review.md
+++ b/docs/skills/skill-perf-review.md
@@ -1,0 +1,34 @@
+---
+status: DRAFT
+owner: Chief of Staff
+autonomy_level: Shadow
+version: 0.1.0
+last_reviewed: 2026-05-09
+---
+
+# skill-perf-review
+
+## Purpose
+
+Review skill performance, autonomy fit, SLA breaches, and consolidation
+opportunities.
+
+## Inputs
+
+- `reports/skills/*/latest.json`
+- Skill contracts in `docs/skills/`
+- Build logs and retro outputs.
+- Owner feedback and decision records.
+
+## Outputs
+
+- Skill performance digest.
+- Promotion/demotion candidates.
+- Redundant or stale skill list.
+- Pending decisions for owner review.
+
+## Never
+
+- Never promote a skill autonomy level automatically.
+- Never delete or rewrite skill contracts without owner review.
+

--- a/docs/skills/support-triage.md
+++ b/docs/skills/support-triage.md
@@ -1,0 +1,58 @@
+# support-triage
+
+## Owner Agent
+
+Support Lead.
+
+## Vertical
+
+Websites.
+
+## Autonomy
+
+Approve until reply quality is proven.
+
+## Purpose
+
+Classify tickets, draft replies for routine issues, and surface customer pain
+patterns.
+
+## Current Status
+
+Shadow-mode local runtime exists. A real support inbox is not wired yet.
+Until then, the runtime reads optional local intake from
+`state/support_tickets.json` and blocks honestly when that file is absent.
+
+Run locally through the Telegram/tool router:
+
+```powershell
+python scripts/tool_router.py support_triage
+```
+
+## Required Before Runtime
+
+- Ticket source.
+- Ticket categories.
+- Draft reply approval flow.
+- Customer data/privacy boundary.
+- Quality review or CSAT signal.
+
+## Outputs
+
+- Ticket category.
+- Draft reply.
+- Escalation reason.
+- Product/content/engineering issue patterns.
+
+## Success Metrics
+
+- Classification accuracy.
+- Percent of drafts shipped unedited.
+- Response time.
+- CSAT delta when available.
+
+## Never
+
+- Never send external replies without approval until quality is proven.
+- Never expose customer data outside approved systems.
+- Never invent policy, refund, legal, or account details.

--- a/kernel/__init__.py
+++ b/kernel/__init__.py
@@ -1,0 +1,2 @@
+"""Minimal AI company OS work ledger kernel."""
+

--- a/kernel/db.py
+++ b/kernel/db.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DB_PATH = ROOT / "state" / "work_ledger.db"
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS work_items (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    status TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    due_at TEXT,
+    needs_approval INTEGER NOT NULL DEFAULT 0,
+    approval_status TEXT NOT NULL DEFAULT 'NOT_REQUIRED',
+    approved_at TEXT,
+    completion_signal TEXT,
+    next_step TEXT NOT NULL,
+    evidence_json TEXT NOT NULL DEFAULT '[]',
+    result TEXT,
+    idempotency_key TEXT UNIQUE,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_items_status ON work_items(status);
+CREATE INDEX IF NOT EXISTS idx_work_items_due_at ON work_items(due_at);
+CREATE INDEX IF NOT EXISTS idx_work_items_source ON work_items(source);
+
+CREATE TABLE IF NOT EXISTS work_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    work_item_id TEXT NOT NULL REFERENCES work_items(id),
+    event_type TEXT NOT NULL,
+    from_status TEXT,
+    to_status TEXT,
+    note TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+"""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def connect(db_path: str | Path | None = None) -> sqlite3.Connection:
+    path = Path(db_path) if db_path else DEFAULT_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    migrate(conn)
+    return conn
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+    existing = conn.execute("SELECT version FROM schema_version WHERE version = 1").fetchone()
+    if existing is None:
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+            (1, utc_now()),
+        )
+    conn.commit()
+

--- a/kernel/views.py
+++ b/kernel/views.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+from .work_items import list_work_items
+
+
+def _parse_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def work_status(conn: sqlite3.Connection, *, now: datetime | None = None) -> dict[str, Any]:
+    current = now or datetime.now(timezone.utc)
+    items = list_work_items(conn)
+    pending = [item for item in items if item["approval_status"] == "PENDING"]
+    ready = [item for item in items if item["status"] == "READY_FOR_REVIEW"]
+    approved = [item for item in items if item["status"] == "APPROVED"]
+    in_progress = [item for item in items if item["status"] == "IN_PROGRESS"]
+    blocked = [item for item in items if item["status"] == "BLOCKED"]
+    measurement_ready = [item for item in items if item["status"] == "MEASUREMENT_READY"]
+    overdue = [
+        item
+        for item in items
+        if item.get("due_at")
+        and item["status"] not in {"DONE", "CANCELLED"}
+        and (_parse_utc(str(item["due_at"])) or current) < current
+    ]
+    return {
+        "ok": True,
+        "counts": {
+            "open": len(items),
+            "pending_approval": len(pending),
+            "ready_for_review": len(ready),
+            "approved": len(approved),
+            "in_progress": len(in_progress),
+            "blocked": len(blocked),
+            "measurement_ready": len(measurement_ready),
+            "overdue": len(overdue),
+        },
+        "decide": pending,
+        "execute": approved + in_progress,
+        "blocked": blocked,
+        "measure": measurement_ready,
+        "overdue": overdue,
+    }
+
+
+def render_status_text(status: dict[str, Any]) -> str:
+    counts = status.get("counts", {})
+    lines = [
+        "Work Ledger",
+        (
+            f"- Open: {counts.get('open', 0)} | Decide: {counts.get('pending_approval', 0)} | "
+            f"Execute: {counts.get('approved', 0) + counts.get('in_progress', 0)} | "
+            f"Blocked: {counts.get('blocked', 0)} | Overdue: {counts.get('overdue', 0)}"
+        ),
+    ]
+    sections = [
+        ("Decide", status.get("decide", [])),
+        ("Overdue", status.get("overdue", [])),
+        ("Execute", status.get("execute", [])),
+        ("Blocked", status.get("blocked", [])),
+        ("Measure", status.get("measure", [])),
+    ]
+    for heading, items in sections:
+        lines.append("")
+        lines.append(heading)
+        if not items:
+            lines.append("- None")
+            continue
+        for item in items[:8]:
+            lines.append(
+                f"- {item.get('id')} [{item.get('status')}] {item.get('title')} "
+                f"| owner={item.get('owner')} | due={item.get('due_at') or 'n/a'}"
+            )
+            lines.append(f"  Next: {item.get('next_step')}")
+    return "\n".join(lines)

--- a/kernel/views.py
+++ b/kernel/views.py
@@ -82,3 +82,49 @@ def render_status_text(status: dict[str, Any]) -> str:
             )
             lines.append(f"  Next: {item.get('next_step')}")
     return "\n".join(lines)
+
+
+def work_reminders(conn: sqlite3.Connection, *, now: datetime | None = None) -> dict[str, Any]:
+    status = work_status(conn, now=now)
+    action_required: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for bucket, reason in [
+        ("overdue", "Overdue"),
+        ("decide", "Needs approval"),
+        ("blocked", "Blocked"),
+        ("measure", "Needs measurement"),
+    ]:
+        for item in status.get(bucket, []):
+            if not isinstance(item, dict):
+                continue
+            work_id = str(item.get("id", ""))
+            if work_id in seen:
+                continue
+            seen.add(work_id)
+            reminder = dict(item)
+            reminder["reminder_reason"] = reason
+            action_required.append(reminder)
+    return {
+        "ok": True,
+        "needs_attention": bool(action_required),
+        "count": len(action_required),
+        "items": action_required,
+        "status": status,
+    }
+
+
+def render_reminder_text(reminders: dict[str, Any]) -> str:
+    items = reminders.get("items", [])
+    items = items if isinstance(items, list) else []
+    if not items:
+        return "Work reminders: no owner action required."
+    lines = [f"Work reminders: {len(items)} item(s) need owner attention."]
+    for item in items[:8]:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"- {item.get('id')} [{item.get('reminder_reason')}] {item.get('title')} "
+            f"| owner={item.get('owner')} | due={item.get('due_at') or 'n/a'}"
+        )
+        lines.append(f"  Next: {item.get('next_step')}")
+    return "\n".join(lines)

--- a/kernel/work_items.py
+++ b/kernel/work_items.py
@@ -7,7 +7,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from .db import utc_now
+from .db import ROOT, utc_now
 
 
 STATUSES = {
@@ -325,6 +325,15 @@ def scan_ready_for_review_markdown(
         if not re.search(r"READY FOR MA REVIEW|READY FOR REVIEW", text, flags=re.I):
             continue
         rel = path.relative_to(root_path).as_posix()
+        metadata = {
+            "executor": "review_markdown_artifact",
+            "path": rel,
+            "scan_root": str(root_path),
+        }
+        try:
+            metadata["repo_path"] = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            pass
         item, was_created = create_work_item(
             conn,
             title=f"Review required: {path.stem}",
@@ -336,7 +345,7 @@ def scan_ready_for_review_markdown(
             approval_status="PENDING",
             next_step="Review the artifact and approve, reject, or request changes.",
             idempotency_key=f"review:{rel}",
-            metadata={"path": rel},
+            metadata=metadata,
         )
         _ = item
         if was_created:

--- a/kernel/work_items.py
+++ b/kernel/work_items.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .db import utc_now
+
+
+STATUSES = {
+    "NEW",
+    "READY_FOR_REVIEW",
+    "PENDING_APPROVAL",
+    "APPROVED",
+    "IN_PROGRESS",
+    "BLOCKED",
+    "MEASUREMENT_READY",
+    "DONE",
+    "CANCELLED",
+}
+
+OPEN_STATUSES = STATUSES - {"DONE", "CANCELLED"}
+
+
+def _new_id() -> str:
+    return f"work_{uuid.uuid4().hex[:12]}"
+
+
+def _loads(text: str, fallback: Any) -> Any:
+    try:
+        return json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return fallback
+
+
+def row_to_item(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    item = dict(row)
+    item["needs_approval"] = bool(item.get("needs_approval"))
+    item["evidence"] = _loads(str(item.pop("evidence_json", "[]")), [])
+    item["metadata"] = _loads(str(item.pop("metadata_json", "{}")), {})
+    return item
+
+
+def _record_event(
+    conn: sqlite3.Connection,
+    work_item_id: str,
+    event_type: str,
+    from_status: str | None = None,
+    to_status: str | None = None,
+    note: str = "",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO work_events (work_item_id, event_type, from_status, to_status, note, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (work_item_id, event_type, from_status, to_status, note.strip(), utc_now()),
+    )
+
+
+def get_work_item(conn: sqlite3.Connection, work_id: str) -> dict[str, Any] | None:
+    row = conn.execute("SELECT * FROM work_items WHERE id = ?", (work_id,)).fetchone()
+    return row_to_item(row)
+
+
+def create_work_item(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    work_type: str,
+    source: str,
+    status: str = "NEW",
+    owner: str = "Unassigned",
+    due_at: str | None = None,
+    needs_approval: bool = False,
+    approval_status: str | None = None,
+    completion_signal: str | None = None,
+    next_step: str | None = None,
+    idempotency_key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], bool]:
+    title = title.strip()
+    source = source.strip()
+    work_type = work_type.strip() or "task"
+    status = status.strip().upper()
+    if not title:
+        raise ValueError("title is required")
+    if not source:
+        raise ValueError("source is required")
+    if status not in STATUSES:
+        raise ValueError(f"invalid status: {status}")
+    if idempotency_key:
+        existing = conn.execute(
+            "SELECT * FROM work_items WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        if existing is not None:
+            return row_to_item(existing) or {}, False
+
+    now = utc_now()
+    work_id = _new_id()
+    resolved_approval = approval_status or ("PENDING" if needs_approval else "NOT_REQUIRED")
+    resolved_next = next_step or _default_next_step(status, bool(needs_approval))
+    conn.execute(
+        """
+        INSERT INTO work_items (
+            id, title, type, source, status, owner, due_at, needs_approval,
+            approval_status, approved_at, completion_signal, next_step, evidence_json,
+            result, idempotency_key, metadata_json, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, '[]', NULL, ?, ?, ?, ?)
+        """,
+        (
+            work_id,
+            title,
+            work_type,
+            source,
+            status,
+            owner.strip() or "Unassigned",
+            due_at,
+            1 if needs_approval else 0,
+            resolved_approval,
+            completion_signal,
+            resolved_next,
+            idempotency_key,
+            json.dumps(metadata or {}, sort_keys=True),
+            now,
+            now,
+        ),
+    )
+    _record_event(conn, work_id, "created", None, status, "Work item created.")
+    conn.commit()
+    return get_work_item(conn, work_id) or {}, True
+
+
+def _default_next_step(status: str, needs_approval: bool) -> str:
+    if status in {"READY_FOR_REVIEW", "PENDING_APPROVAL"} or needs_approval:
+        return "CEO review required."
+    if status == "APPROVED":
+        return "Assign owner, due date, and completion signal before execution."
+    if status == "IN_PROGRESS":
+        return "Complete work and attach evidence."
+    return "Clarify next step."
+
+
+def approve_work_item(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    owner: str,
+    due_at: str,
+    completion_signal: str,
+    next_step: str | None = None,
+) -> dict[str, Any]:
+    item = get_work_item(conn, work_id)
+    if item is None:
+        raise ValueError(f"work item not found: {work_id}")
+    owner = owner.strip()
+    due_at = due_at.strip()
+    completion_signal = completion_signal.strip()
+    if not owner or not due_at or not completion_signal:
+        raise ValueError("approval requires owner, due_at, and completion_signal")
+    prior = str(item["status"])
+    now = utc_now()
+    conn.execute(
+        """
+        UPDATE work_items
+        SET status = 'APPROVED',
+            owner = ?,
+            due_at = ?,
+            approval_status = 'APPROVED',
+            approved_at = ?,
+            completion_signal = ?,
+            next_step = ?,
+            updated_at = ?
+        WHERE id = ?
+        """,
+        (
+            owner,
+            due_at,
+            now,
+            completion_signal,
+            (next_step or "Start execution and attach evidence when complete.").strip(),
+            now,
+            work_id,
+        ),
+    )
+    _record_event(conn, work_id, "approved", prior, "APPROVED", completion_signal)
+    conn.commit()
+    return get_work_item(conn, work_id) or {}
+
+
+def start_work_item(conn: sqlite3.Connection, work_id: str, note: str = "") -> dict[str, Any]:
+    item = get_work_item(conn, work_id)
+    if item is None:
+        raise ValueError(f"work item not found: {work_id}")
+    if item["approval_status"] == "PENDING":
+        raise ValueError("CEO approval is required before execution")
+    prior = str(item["status"])
+    now = utc_now()
+    conn.execute(
+        "UPDATE work_items SET status = 'IN_PROGRESS', next_step = ?, updated_at = ? WHERE id = ?",
+        ("Complete work and attach evidence.", now, work_id),
+    )
+    _record_event(conn, work_id, "started", prior, "IN_PROGRESS", note)
+    conn.commit()
+    return get_work_item(conn, work_id) or {}
+
+
+def block_work_item(conn: sqlite3.Connection, work_id: str, reason: str) -> dict[str, Any]:
+    item = get_work_item(conn, work_id)
+    if item is None:
+        raise ValueError(f"work item not found: {work_id}")
+    reason = reason.strip()
+    if not reason:
+        raise ValueError("blocked reason is required")
+    prior = str(item["status"])
+    now = utc_now()
+    conn.execute(
+        "UPDATE work_items SET status = 'BLOCKED', next_step = ?, updated_at = ? WHERE id = ?",
+        (f"Blocked: {reason}", now, work_id),
+    )
+    _record_event(conn, work_id, "blocked", prior, "BLOCKED", reason)
+    conn.commit()
+    return get_work_item(conn, work_id) or {}
+
+
+def done_work_item(
+    conn: sqlite3.Connection,
+    work_id: str,
+    *,
+    result: str,
+    evidence: str,
+) -> dict[str, Any]:
+    item = get_work_item(conn, work_id)
+    if item is None:
+        raise ValueError(f"work item not found: {work_id}")
+    result = result.strip()
+    evidence = evidence.strip()
+    if not result or not evidence:
+        raise ValueError("done requires result and evidence")
+    prior = str(item["status"])
+    evidence_rows = item.get("evidence", [])
+    evidence_rows = evidence_rows if isinstance(evidence_rows, list) else []
+    evidence_rows.append({"summary": evidence, "captured_at": utc_now()})
+    now = utc_now()
+    conn.execute(
+        """
+        UPDATE work_items
+        SET status = 'DONE',
+            result = ?,
+            evidence_json = ?,
+            next_step = 'Closed.',
+            updated_at = ?
+        WHERE id = ?
+        """,
+        (result, json.dumps(evidence_rows, sort_keys=True), now, work_id),
+    )
+    _record_event(conn, work_id, "done", prior, "DONE", result)
+    conn.commit()
+    return get_work_item(conn, work_id) or {}
+
+
+def list_work_items(
+    conn: sqlite3.Connection,
+    *,
+    statuses: list[str] | None = None,
+    include_closed: bool = False,
+) -> list[dict[str, Any]]:
+    params: list[Any] = []
+    clauses: list[str] = []
+    if statuses:
+        clean = [status.strip().upper() for status in statuses if status.strip()]
+        placeholders = ",".join("?" for _ in clean)
+        clauses.append(f"status IN ({placeholders})")
+        params.extend(clean)
+    elif not include_closed:
+        placeholders = ",".join("?" for _ in sorted(OPEN_STATUSES))
+        clauses.append(f"status IN ({placeholders})")
+        params.extend(sorted(OPEN_STATUSES))
+    where = "WHERE " + " AND ".join(clauses) if clauses else ""
+    rows = conn.execute(
+        f"SELECT * FROM work_items {where} ORDER BY due_at IS NULL, due_at, created_at",
+        params,
+    ).fetchall()
+    return [item for row in rows if (item := row_to_item(row)) is not None]
+
+
+def scan_ready_for_review_markdown(
+    conn: sqlite3.Connection,
+    *,
+    root: str | Path,
+) -> dict[str, Any]:
+    root_path = Path(root)
+    created = 0
+    existing = 0
+    skipped_dirs = {
+        ".claude",
+        ".git",
+        ".gstack",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "artifacts",
+        "logs",
+        "memory",
+        "node_modules",
+        "reports",
+        "state",
+    }
+    for path in root_path.rglob("*.md"):
+        if any(part in skipped_dirs for part in path.parts):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not re.search(r"READY FOR MA REVIEW|READY FOR REVIEW", text, flags=re.I):
+            continue
+        rel = path.relative_to(root_path).as_posix()
+        item, was_created = create_work_item(
+            conn,
+            title=f"Review required: {path.stem}",
+            work_type="review",
+            source=f"markdown:{rel}",
+            status="READY_FOR_REVIEW",
+            owner="CEO",
+            needs_approval=True,
+            approval_status="PENDING",
+            next_step="Review the artifact and approve, reject, or request changes.",
+            idempotency_key=f"review:{rel}",
+            metadata={"path": rel},
+        )
+        _ = item
+        if was_created:
+            created += 1
+        else:
+            existing += 1
+    return {"ok": True, "created": created, "existing": existing}

--- a/kernel/worker.py
+++ b/kernel/worker.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from .views import render_status_text, work_status
+from .work_items import block_work_item, done_work_item, list_work_items, start_work_item
+
+
+def run_next_work_item(conn: sqlite3.Connection) -> dict[str, Any]:
+    approved = list_work_items(conn, statuses=["APPROVED"])
+    if not approved:
+        return {"ok": True, "ran": False, "message": "No approved work items are ready to run.", "item": None}
+
+    item = approved[0]
+    started = start_work_item(conn, str(item["id"]), note="Worker picked up approved work.")
+    executor = str(started.get("metadata", {}).get("executor", "")).strip()
+    if executor == "ledger_status_snapshot":
+        status = work_status(conn)
+        text = render_status_text(status)
+        done = done_work_item(
+            conn,
+            str(started["id"]),
+            result="Ledger status snapshot generated.",
+            evidence=text,
+        )
+        return {
+            "ok": True,
+            "ran": True,
+            "outcome": "done",
+            "executor": executor,
+            "item": done,
+        }
+
+    reason = (
+        f"No automated executor is registered for type={started.get('type')} "
+        f"source={started.get('source')}."
+    )
+    blocked = block_work_item(conn, str(started["id"]), reason)
+    return {
+        "ok": True,
+        "ran": True,
+        "outcome": "blocked",
+        "executor": executor or None,
+        "item": blocked,
+        "reason": reason,
+    }

--- a/kernel/worker.py
+++ b/kernel/worker.py
@@ -1,10 +1,67 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 from typing import Any
 
+from .db import ROOT
 from .views import render_status_text, work_status
 from .work_items import block_work_item, done_work_item, list_work_items, start_work_item
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_review_markdown_path(item: dict[str, Any]) -> Path | None:
+    metadata = item.get("metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    repo_path = str(metadata.get("repo_path", "")).strip()
+    if repo_path:
+        candidate = (ROOT / repo_path).resolve()
+        if candidate.suffix.lower() == ".md" and _is_relative_to(candidate, ROOT.resolve()) and candidate.exists():
+            return candidate
+
+    scan_root = str(metadata.get("scan_root", "")).strip()
+    rel_path = str(metadata.get("path", "")).strip()
+    if scan_root and rel_path:
+        root = Path(scan_root).resolve()
+        candidate = (root / rel_path).resolve()
+        if candidate.suffix.lower() == ".md" and _is_relative_to(candidate, root) and candidate.exists():
+            return candidate
+    return None
+
+
+def _review_markdown_summary(path: Path, text: str) -> str:
+    lines = [line.strip() for line in text.splitlines()]
+    heading = next((line.lstrip("#").strip() for line in lines if line.startswith("#")), path.stem)
+    status = next((line for line in lines if "status" in line.lower()), "Status: not found")
+    checked = sum(1 for line in lines if line.startswith("- [x]") or line.startswith("- [X]"))
+    unchecked = sum(1 for line in lines if line.startswith("- [ ]"))
+    substantive = [
+        line
+        for line in lines
+        if line
+        and not line.startswith("#")
+        and not line.startswith("- [")
+        and "READY FOR MA REVIEW" not in line.upper()
+        and "READY FOR REVIEW" not in line.upper()
+    ]
+    excerpts = substantive[:5]
+    summary_lines = [
+        f"Review artifact summarized: {path.name}",
+        f"Heading: {heading}",
+        status,
+        f"Checklist: {checked} checked, {unchecked} open",
+    ]
+    if excerpts:
+        summary_lines.append("Key lines:")
+        summary_lines.extend(f"- {line[:220]}" for line in excerpts)
+    return "\n".join(summary_lines)
 
 
 def run_next_work_item(conn: sqlite3.Connection) -> dict[str, Any]:
@@ -23,6 +80,47 @@ def run_next_work_item(conn: sqlite3.Connection) -> dict[str, Any]:
             str(started["id"]),
             result="Ledger status snapshot generated.",
             evidence=text,
+        )
+        return {
+            "ok": True,
+            "ran": True,
+            "outcome": "done",
+            "executor": executor,
+            "item": done,
+        }
+
+    if executor == "review_markdown_artifact":
+        path = _resolve_review_markdown_path(started)
+        if path is None:
+            reason = "Review markdown artifact path is missing, unsafe, or no longer exists."
+            blocked = block_work_item(conn, str(started["id"]), reason)
+            return {
+                "ok": True,
+                "ran": True,
+                "outcome": "blocked",
+                "executor": executor,
+                "item": blocked,
+                "reason": reason,
+            }
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            reason = f"Review markdown artifact could not be read: {exc}"
+            blocked = block_work_item(conn, str(started["id"]), reason)
+            return {
+                "ok": True,
+                "ran": True,
+                "outcome": "blocked",
+                "executor": executor,
+                "item": blocked,
+                "reason": reason,
+            }
+        evidence = _review_markdown_summary(path, text)
+        done = done_work_item(
+            conn,
+            str(started["id"]),
+            result="Review artifact summarized for owner decision record.",
+            evidence=evidence,
         )
         return {
             "ok": True,

--- a/memory/schema.md
+++ b/memory/schema.md
@@ -1,0 +1,62 @@
+# Memory Schema
+
+Status: v0
+
+## Purpose
+
+Memory preserves decisions, lessons, recurring facts, owner preferences, and
+evidence references so personas and skills do not start from zero.
+
+Memory is context, not proof, unless the row records a decision or standing
+instruction. Current operating truth still comes first from `state/`,
+`reports/`, `reports/skills/`, and `docs/decisions/`.
+
+## Storage
+
+Current local store:
+
+- `memory/vector_store.jsonl`
+
+Each line should be a JSON object.
+
+## Required Fields
+
+```json
+{
+  "text": "Human-readable memory text.",
+  "metadata": {
+    "type": "decision|lesson|owner_preference|fact|artifact_reference",
+    "source": "path/or/system",
+    "created_at_utc": "2026-05-09T00:00:00+00:00",
+    "tags": ["optional", "tags"]
+  }
+}
+```
+
+## Accepted Types
+
+| Type | Meaning |
+|---|---|
+| `decision` | Owner or authorized operating decision |
+| `lesson` | Retrospective learning or repeated pattern |
+| `owner_preference` | Stable preference or instruction from the owner |
+| `fact` | Durable fact, usually copied from a report |
+| `artifact_reference` | Pointer to a report, review, retro, or decision |
+
+## Write Rules
+
+- Write memory for decisions, lessons, recurring facts, and owner preferences.
+- Do not write raw secrets, credentials, tokens, payment details, or private
+  keys.
+- Do not treat chat alone as durable proof.
+- Include a source path whenever possible.
+- If a fact changes frequently, store the artifact reference rather than a stale
+  value.
+
+## Read Rules
+
+- Persona default openings may read memory samples, but must prioritize
+  deterministic state and reports.
+- Follow-up model calls may use memory only after current state is retrieved.
+- If memory conflicts with current reports or state, current reports/state win.
+

--- a/operating-room/README.md
+++ b/operating-room/README.md
@@ -1,0 +1,52 @@
+# Operating Room MVP
+
+This is a local front office for the AI Holding Company.
+
+## Rule
+
+Persona conversation accepts free text. The system first builds a deterministic
+truth packet from `state/`, `reports/`, and approved memory files. Today, a
+deterministic fallback verbalizer turns that packet into text. The future
+NanoClaw layer may replace only that verbalizer step.
+
+## Generate Snapshot
+
+```powershell
+python scripts/operating_room_snapshot.py
+```
+
+## View
+
+For the full operating room, including persona chat, run the local-only server:
+
+```powershell
+python scripts/operating_room_server.py --port 8765
+```
+
+Then visit:
+
+```text
+http://127.0.0.1:8765/operating-room/
+```
+
+The static files still open without the server, but persona chat requires the
+local `/api/persona-chat` endpoint.
+
+Persona replies include the natural answer plus collapsed evidence rows and
+source paths. The chat transcript is display state only; the system does not use
+chat history as truth.
+
+See `docs/communication/nanoclaw-conversation-layer.md` for the NanoClaw
+conversation-layer contract.
+
+## Shadow Testing
+
+The local NanoClaw shadow simulator can test the inbox/outbox contract without
+calling a model:
+
+```powershell
+python scripts/tool_router.py nanoclaw_shadow_write
+```
+
+This only writes a candidate shadow response. It does not change the live
+persona answer.

--- a/operating-room/app.js
+++ b/operating-room/app.js
@@ -1,0 +1,256 @@
+const state = {
+  snapshot: null,
+  currentView: "today",
+  selectedPersona: "chief-of-staff",
+  personaMessages: [],
+};
+
+const titles = {
+  today: "Today",
+  approvals: "Approvals",
+  memory: "Memory",
+  personas: "Personas",
+};
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function pill(status) {
+  const clean = escapeHtml(status || "UNKNOWN");
+  return `<span class="pill ${clean}">${clean}</span>`;
+}
+
+function renderToday(view) {
+  const items = view.items || [];
+  return `
+    <article class="card">
+      <h2>Company Opening</h2>
+      <p>${pill(view.status)} The first screen is a deterministic digest from local artifacts.</p>
+    </article>
+    ${items.map((item) => `
+      <article class="card">
+        <div class="row">
+          <div>
+            <h3>${escapeHtml(item.skill)}</h3>
+            <p>${escapeHtml(item.brief)}</p>
+            <p class="muted"><code>${escapeHtml(item.source)}</code></p>
+          </div>
+          ${pill(item.status)}
+        </div>
+      </article>
+    `).join("")}
+  `;
+}
+
+function renderApprovals(view) {
+  const pending = view.pending || [];
+  if (!pending.length) {
+    return `<article class="card"><h2>No Pending Approvals</h2><p class="muted">No approval items were found in local state.</p></article>`;
+  }
+  return `
+    <article class="card"><h2>${pending.length} Pending Approval${pending.length === 1 ? "" : "s"}</h2></article>
+    ${pending.map((item) => `
+      <article class="card">
+        <h3>${escapeHtml(item.topic)}</h3>
+        <p>${escapeHtml(item.decision)}</p>
+        <p class="muted"><code>${escapeHtml(item.approval_id)}</code></p>
+        ${pill(item.priority)}
+      </article>
+    `).join("")}
+  `;
+}
+
+function renderMemory(view) {
+  const samples = view.samples || [];
+  if (!samples.length) {
+    return `<article class="card"><h2>No Memory Samples</h2><p class="muted">No local memory rows were available for this snapshot.</p></article>`;
+  }
+  return samples.map((item) => `
+    <article class="card">
+      <p>${escapeHtml(item.text)}</p>
+      <p class="muted">${escapeHtml(JSON.stringify(item.metadata || {}))}</p>
+    </article>
+  `).join("");
+}
+
+function renderPersonas(view) {
+  const personas = view.personas || [];
+  const selected = personas.find((persona) => persona.slug === state.selectedPersona) || personas[0] || {};
+  const transcript = state.personaMessages.length
+    ? state.personaMessages.map((item) => `
+      <div class="message ${escapeHtml(item.role)}">
+        <p>${escapeHtml(item.text)}</p>
+        ${item.evidence?.length ? `
+          <details class="evidence-details">
+            <summary>Evidence (${item.evidence.length})</summary>
+            <div class="evidence-list">
+            ${item.evidence.map((evidence) => `
+              <div class="evidence-item">
+                <strong>${escapeHtml(evidence.status)} ${escapeHtml(evidence.skill)}</strong>
+                <span>${escapeHtml(evidence.brief)}</span>
+                <code>${escapeHtml(evidence.source)}</code>
+              </div>
+            `).join("")}
+            </div>
+          </details>
+        ` : ""}
+        ${item.shadow ? `
+          <p class="shadow-status">
+            Shadow: ${escapeHtml(item.shadow.enabled === false ? "disabled" : item.shadow.accepted ? "accepted" : item.shadow.reason || "pending")}
+          </p>
+          ${item.shadow.answer ? `<p class="shadow-answer">${escapeHtml(item.shadow.answer)}</p>` : ""}
+        ` : ""}
+        ${item.sources?.length ? `<details class="source-details"><summary>Source paths</summary><p>${item.sources.map(escapeHtml).join(", ")}</p></details>` : ""}
+      </div>
+    `).join("")
+    : `<p class="muted">Ask any natural question. The reply is grounded against local org truth, not chat memory.</p>`;
+  return `
+    <section class="persona-layout">
+      <aside class="persona-list" aria-label="Employees">
+        ${personas.map((persona) => `
+          <button class="persona-button ${persona.slug === state.selectedPersona ? "is-active" : ""}" data-persona="${escapeHtml(persona.slug)}" type="button">
+            <span>${escapeHtml(persona.name)}</span>
+            ${pill(persona.status)}
+          </button>
+        `).join("")}
+      </aside>
+      <article class="card chat-panel">
+        <div class="chat-header">
+          <div>
+            <h2>${escapeHtml(selected.name || "Persona")}</h2>
+            <p class="muted"><code>${escapeHtml(selected.contract || "")}</code></p>
+          </div>
+          <div class="chat-actions">
+            <span class="truth-badge">Truth-first</span>
+            <button id="shadow-write" class="secondary-button" type="button">Run Shadow</button>
+          </div>
+        </div>
+        <div id="persona-transcript" class="transcript">${transcript}</div>
+        <form id="persona-chat-form" class="chat-form">
+          <textarea id="persona-message" name="message" rows="3" placeholder="Talk naturally. The employee will answer from stored truth." required></textarea>
+          <button type="submit">Send</button>
+        </form>
+      </article>
+    </section>
+  `;
+}
+
+function render() {
+  const root = document.querySelector("#view-root");
+  const title = document.querySelector("#view-title");
+  title.textContent = titles[state.currentView] || "Operating Room";
+  if (!state.snapshot) {
+    root.innerHTML = `<article class="card"><h2>Snapshot Missing</h2><p>Run <code>python scripts/operating_room_snapshot.py</code>.</p></article>`;
+    return;
+  }
+  const view = state.snapshot.views[state.currentView] || {};
+  if (state.currentView === "today") root.innerHTML = renderToday(view);
+  if (state.currentView === "approvals") root.innerHTML = renderApprovals(view);
+  if (state.currentView === "memory") root.innerHTML = renderMemory(view);
+  if (state.currentView === "personas") root.innerHTML = renderPersonas(view);
+  bindPersonaControls();
+}
+
+function bindPersonaControls() {
+  document.querySelectorAll(".persona-button").forEach((button) => {
+    button.addEventListener("click", () => {
+      state.selectedPersona = button.dataset.persona;
+      state.personaMessages = [];
+      render();
+    });
+  });
+  const form = document.querySelector("#persona-chat-form");
+  if (!form) return;
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const input = document.querySelector("#persona-message");
+    const message = input.value.trim();
+    if (!message) return;
+    state.personaMessages.push({ role: "owner", text: message, sources: [], evidence: [] });
+    input.value = "";
+    render();
+    try {
+      const response = await fetch("/api/persona-chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ persona: state.selectedPersona, message }),
+      });
+      const payload = await response.json();
+      state.personaMessages.push({
+        role: "persona",
+        text: payload.answer || payload.error || "No answer returned.",
+        sources: payload.sources || [],
+        evidence: payload.evidence || [],
+        shadow: payload.shadow_verbalizer || null,
+      });
+    } catch (_error) {
+      state.personaMessages.push({
+        role: "persona",
+        text: "Start the local server with python scripts/operating_room_server.py to chat here.",
+        sources: [],
+        evidence: [],
+        shadow: null,
+      });
+    }
+    render();
+  });
+  const shadowButton = document.querySelector("#shadow-write");
+  if (shadowButton) {
+    shadowButton.addEventListener("click", async () => {
+      try {
+        const response = await fetch("/api/nanoclaw-shadow-write", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        });
+        const payload = await response.json();
+        state.personaMessages.push({
+          role: "persona",
+          text: payload.ok
+            ? "Shadow candidate written. Ask the same question again to compare it."
+            : `Shadow writer did not run: ${payload.error || "unknown reason"}.`,
+          sources: [],
+          evidence: [],
+          shadow: null,
+        });
+      } catch (_error) {
+        state.personaMessages.push({
+          role: "persona",
+          text: "Shadow writer is unavailable from this local server.",
+          sources: [],
+          evidence: [],
+          shadow: null,
+        });
+      }
+      render();
+    });
+  }
+}
+
+async function loadSnapshot() {
+  try {
+    const response = await fetch("snapshot.json", { cache: "no-store" });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    state.snapshot = await response.json();
+    document.querySelector("#generated-at").textContent = `Generated ${state.snapshot.generated_at_utc}`;
+  } catch (_error) {
+    state.snapshot = null;
+  }
+  render();
+}
+
+document.querySelectorAll(".nav").forEach((button) => {
+  button.addEventListener("click", () => {
+    document.querySelectorAll(".nav").forEach((node) => node.classList.remove("is-active"));
+    button.classList.add("is-active");
+    state.currentView = button.dataset.view;
+    render();
+  });
+});
+
+loadSnapshot();

--- a/operating-room/index.html
+++ b/operating-room/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AI Holding Company Operating Room</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="shell">
+    <aside class="rail" aria-label="Operating room views">
+      <div class="brand">
+        <span class="brand__mark">AIHC</span>
+        <span class="brand__text">Operating Room</span>
+      </div>
+      <button class="nav is-active" data-view="today" type="button">Today</button>
+      <button class="nav" data-view="approvals" type="button">Approvals</button>
+      <button class="nav" data-view="memory" type="button">Memory</button>
+      <button class="nav" data-view="personas" type="button">Personas</button>
+    </aside>
+
+    <section class="workspace">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Read-only MVP</p>
+          <h1 id="view-title">Today</h1>
+        </div>
+        <p id="generated-at" class="timestamp">Generate snapshot first</p>
+      </header>
+      <section id="view-root" class="view" aria-live="polite"></section>
+    </section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>
+

--- a/operating-room/snapshot.json
+++ b/operating-room/snapshot.json
@@ -1,0 +1,190 @@
+{
+  "ok": true,
+  "generated_at_utc": "2026-05-10T06:27:02.532809+00:00",
+  "read_only": true,
+  "rule": "Persona chat is free text, then deterministic grounding against local truth; no model calls.",
+  "views": {
+    "today": {
+      "status": "BLOCKED",
+      "items": [
+        {
+          "skill": "backtest-review",
+          "status": "BLOCKED",
+          "owner_need": "none",
+          "brief": "Backtest review is BLOCKED. Latest MT5 research selected 8 candidate(s), approved 0, rejected 7, and has 0 out-of-sample / 0 walk-forward evidence. No reviewed candidate is approved.",
+          "source": "reports/skills/backtest-review/latest.json"
+        },
+        {
+          "skill": "portfolio-retro-weekly",
+          "status": "BLOCKED",
+          "owner_need": "approve",
+          "brief": "Portfolio retro is BLOCKED. 3 unresolved issue(s) remain, led by backtest-review: Backtest review is BLOCKED. Latest MT5 research selected 8 candidate(s), approved 0, rejected 7, and has 0 out-of-sample / 0 walk-forward evidence. No reviewed candidate is approved.",
+          "source": "reports/skills/portfolio-retro-weekly/latest.json"
+        },
+        {
+          "skill": "support-triage",
+          "status": "BLOCKED",
+          "owner_need": "none",
+          "brief": "Support triage is BLOCKED. No local support ticket source found at state/support_tickets.json.",
+          "source": "reports/skills/support-triage/latest.json"
+        },
+        {
+          "skill": "risk-aggregate-daily",
+          "status": "RED",
+          "owner_need": "approve",
+          "brief": "The company is RED in the latest stored CEO report. Property forecast attainment is RED (4.1% vs target >= 100%). You have one approval waiting, led by Company KPI: Property forecast attainment. There are also 11 approved items waiting for execution follow-through.",
+          "source": "reports/skills/risk-aggregate-daily/latest.json"
+        },
+        {
+          "skill": "data-quality-daily",
+          "status": "GREEN",
+          "owner_need": "none",
+          "brief": "Trading data quality is GREEN for the local checks that currently exist. Missing vendor and broker checks are explicitly marked N/A.",
+          "source": "reports/skills/data-quality-daily/latest.json"
+        }
+      ]
+    },
+    "approvals": {
+      "pending_count": 1,
+      "pending": [
+        {
+          "approval_id": "board_company-kpi-property-forecast-attain",
+          "topic": "Company KPI: Property forecast attainment",
+          "priority": "RED",
+          "decision": "Prioritize monetization levers that increase MRR progress to 90-day targets."
+        }
+      ],
+      "source": "state/board_approval_decisions.json"
+    },
+    "memory": {
+      "sample_count": 8,
+      "samples": [
+        {
+          "text": "Daily brief 2026-05-04: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-04T01:43:25.758475+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-04: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-04T01:48:23.896898+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-04: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-04T14:00:05.294166+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-05: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-05T14:00:04.571495+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-06: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-06T14:00:05.447678+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-07: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-07T14:00:04.589547+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-08: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-08T14:00:05.674859+00:00"
+          }
+        },
+        {
+          "text": "Daily brief 2026-05-09: total PnL=$+0.00, trades=0, errors=0, websites 2/2 up.",
+          "metadata": {
+            "type": "daily_brief_fact",
+            "generated_at_utc": "2026-05-09T14:00:05.781817+00:00"
+          }
+        }
+      ],
+      "source": "memory/vector_store.jsonl"
+    },
+    "personas": {
+      "personas": [
+        {
+          "name": "Chief of Staff",
+          "slug": "chief-of-staff",
+          "grounding": "Reads company-level risk, approvals, current skill outputs, and retros.",
+          "contract": "docs/personas/chief-of-staff/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Risk Officer",
+          "slug": "risk-officer",
+          "grounding": "Reads guardrail artifacts, risk blocks, and approval state.",
+          "contract": "docs/personas/risk-officer/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Quant Ops",
+          "slug": "quant-ops",
+          "grounding": "Reads trading data-quality, backtest-review, and broker-reconcile artifacts.",
+          "contract": "docs/personas/quant-ops/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Growth Lead",
+          "slug": "growth-lead",
+          "grounding": "Reads website analytics, growth digests, and portfolio retro evidence.",
+          "contract": "docs/personas/growth-lead/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Editorial Lead",
+          "slug": "editorial-lead",
+          "grounding": "Reads content queue, draft, SEO, and analytics evidence when present.",
+          "contract": "docs/personas/editorial-lead/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Engineering/Ops",
+          "slug": "engineering-ops",
+          "grounding": "Reads operating briefs, reliability records, and deploy/incident evidence.",
+          "contract": "docs/personas/engineering-ops/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Support Lead",
+          "slug": "support-lead",
+          "grounding": "Reads support-triage output and local ticket sources when present.",
+          "contract": "docs/personas/support-lead/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        },
+        {
+          "name": "Finance/Admin",
+          "slug": "finance-admin",
+          "grounding": "Deferred until reliable finance and admin sources exist.",
+          "contract": "docs/personas/finance-admin/contract.md",
+          "status": "ready",
+          "deterministic_grounding": true
+        }
+      ]
+    }
+  }
+}

--- a/operating-room/styles.css
+++ b/operating-room/styles.css
@@ -1,0 +1,368 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6f8;
+  --panel: #ffffff;
+  --ink: #19212a;
+  --muted: #667085;
+  --line: #d7dde5;
+  --accent: #1f7a5b;
+  --risk: #b42318;
+  --warn: #b54708;
+  --ok: #027a48;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+}
+
+.rail {
+  background: #17202a;
+  color: #fff;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  background: var(--accent);
+  border-radius: 6px;
+  font-weight: 700;
+}
+
+.brand__text {
+  font-weight: 700;
+}
+
+.nav {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: transparent;
+  color: #fff;
+  border-radius: 6px;
+  padding: 11px 12px;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.nav.is-active {
+  background: #fff;
+  color: #17202a;
+}
+
+.workspace {
+  padding: 28px;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.eyebrow,
+.timestamp,
+.muted {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+h1 {
+  margin: 4px 0 0;
+  font-size: 28px;
+}
+
+.view {
+  display: grid;
+  gap: 14px;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.card h2,
+.card h3 {
+  margin: 0 0 8px;
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+  margin-top: 12px;
+}
+
+.persona-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.persona-list {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.persona-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  border-radius: 8px;
+  padding: 12px;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.persona-button.is-active {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.chat-panel {
+  display: grid;
+  gap: 14px;
+  min-height: 560px;
+}
+
+.chat-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 12px;
+}
+
+.chat-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.truth-badge {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.secondary-button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  padding: 7px 10px;
+}
+
+.transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 300px;
+}
+
+.message {
+  max-width: 78%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.message p {
+  margin: 0;
+}
+
+.evidence-details {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.evidence-details summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.evidence-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.evidence-item {
+  display: grid;
+  gap: 4px;
+  border-left: 3px solid var(--line);
+  padding-left: 9px;
+  font-size: 13px;
+}
+
+.evidence-item strong {
+  color: var(--ink);
+}
+
+.evidence-item span {
+  color: var(--muted);
+}
+
+.source-details {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.source-details summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.source-details p {
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+}
+
+.shadow-status,
+.shadow-answer {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.shadow-answer {
+  border-left: 3px solid var(--accent);
+  padding-left: 9px;
+}
+
+.message.persona {
+  background: #f8fafc;
+}
+
+.message.owner {
+  align-self: flex-end;
+  background: #eaf6f1;
+  border-color: #b8dfd0;
+}
+
+.chat-form {
+  display: grid;
+  gap: 10px;
+  margin-top: auto;
+}
+
+.chat-form textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  font: inherit;
+}
+
+.chat-form button {
+  justify-self: end;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  padding: 10px 18px;
+  cursor: pointer;
+}
+
+.pill {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  background: var(--muted);
+}
+
+.pill.GREEN {
+  background: var(--ok);
+}
+
+.pill.RED,
+.pill.BLOCKED {
+  background: var(--risk);
+}
+
+.pill.AMBER,
+.pill.YELLOW {
+  background: var(--warn);
+}
+
+code {
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .rail {
+    min-height: auto;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .persona-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .message {
+    max-width: 100%;
+  }
+}

--- a/retros/_template.md
+++ b/retros/_template.md
@@ -1,0 +1,29 @@
+# Retro: <Scope> <Period>
+
+Period: YYYY-MM-DD to YYYY-MM-DD
+Owner: <Owner or persona>
+
+## Summary
+
+What happened, in plain English?
+
+## Wins
+
+- 
+
+## Issues
+
+- 
+
+## Decisions Logged
+
+- 
+
+## Follow-Through
+
+- [ ] Action, owner, due date
+
+## Evidence
+
+- `<path/to/source>`
+

--- a/scripts/aiogram_bridge.py
+++ b/scripts/aiogram_bridge.py
@@ -1375,7 +1375,7 @@ def _format_help() -> str:
         "- /loop new <goal>\n"
         "- /loop status\n"
         "- /loop show <loop_id>\n"
-        "- /work [status|scan_reviews]\n"
+        "- /work [status|scan_reviews|show|approve|start|block|done]\n"
         "- /brief\n"
         "- /memory <query>\n"
         "- /bot <bot_id> health|report|logs [lines]|execute [confirm]\n"
@@ -1707,13 +1707,54 @@ async def _handle_loop_command(text: str) -> str:
 
 async def _handle_work_command(text: str) -> str:
     payload = re.sub(r"^/work\s*", "", text, count=1, flags=re.I).strip()
-    action = payload.lower() or "status"
+    parts = payload.split(maxsplit=1)
+    action = parts[0].lower() if parts else "status"
+    rest = parts[1] if len(parts) > 1 else ""
     if action in {"status"}:
         args = ["work", "status"]
     elif action in {"scan", "scan_reviews", "refresh"}:
         args = ["work", "scan_reviews"]
+    elif action == "show":
+        if not rest.strip():
+            return "Use `/work show <work_id>`."
+        args = ["work", "show", "--work-id", rest.strip()]
+    elif action == "approve":
+        fields = [field.strip() for field in rest.split("|")]
+        if len(fields) < 4 or not all(fields[:4]):
+            return "Use `/work approve <work_id> | <owner> | <due_at> | <completion_signal>`."
+        args = [
+            "work",
+            "approve",
+            "--work-id",
+            fields[0],
+            "--owner",
+            fields[1],
+            "--due-at",
+            fields[2],
+            "--completion-signal",
+            fields[3],
+        ]
+        if len(fields) > 4 and fields[4]:
+            args.extend(["--next-step", fields[4]])
+    elif action == "start":
+        fields = rest.split(maxsplit=1)
+        if not fields or not fields[0].strip():
+            return "Use `/work start <work_id> [note]`."
+        args = ["work", "start", "--work-id", fields[0]]
+        if len(fields) > 1:
+            args.extend(["--note", fields[1]])
+    elif action == "block":
+        fields = rest.split(maxsplit=1)
+        if len(fields) < 2 or not fields[0].strip() or not fields[1].strip():
+            return "Use `/work block <work_id> <reason>`."
+        args = ["work", "block", "--work-id", fields[0], "--reason", fields[1]]
+    elif action == "done":
+        fields = [field.strip() for field in rest.split("|")]
+        if len(fields) < 3 or not all(fields[:3]):
+            return "Use `/work done <work_id> | <result> | <evidence>`."
+        args = ["work", "done", "--work-id", fields[0], "--result", fields[1], "--evidence", fields[2]]
     else:
-        return "Use `/work` or `/work scan_reviews`."
+        return "Use `/work status|scan_reviews|show|approve|start|block|done`."
 
     result = await _run_tool_router(args, timeout_sec=180)
     payload_obj = result.get("payload")
@@ -1727,6 +1768,25 @@ async def _handle_work_command(text: str) -> str:
         created = int(payload_obj.get("created", 0) or 0)
         existing = int(payload_obj.get("existing", 0) or 0)
         return f"Review scan complete: created {created}, existing {existing}.\n\n{text_payload}".strip()
+    item = payload_obj.get("item")
+    if isinstance(item, dict):
+        verb = {
+            "show": "Work item",
+            "approve": "Approved",
+            "start": "Started",
+            "block": "Blocked",
+            "done": "Closed",
+        }.get(action, "Work item")
+        evidence = item.get("evidence", [])
+        evidence_count = len(evidence) if isinstance(evidence, list) else 0
+        return (
+            f"{verb}: `{item.get('id')}` [{item.get('status')}]\n"
+            f"Title: {item.get('title')}\n"
+            f"Owner: {item.get('owner')} | Due: {item.get('due_at') or 'n/a'}\n"
+            f"Completion signal: {item.get('completion_signal') or 'n/a'}\n"
+            f"Next: {item.get('next_step')}\n"
+            f"Evidence: {evidence_count}"
+        )
     return text_payload
 
 

--- a/scripts/aiogram_bridge.py
+++ b/scripts/aiogram_bridge.py
@@ -1375,7 +1375,7 @@ def _format_help() -> str:
         "- /loop new <goal>\n"
         "- /loop status\n"
         "- /loop show <loop_id>\n"
-        "- /work [status|scan_reviews|show|approve|start|block|done]\n"
+        "- /work [status|reminders|scan_reviews|show|approve|start|block|done]\n"
         "- /brief\n"
         "- /memory <query>\n"
         "- /bot <bot_id> health|report|logs [lines]|execute [confirm]\n"
@@ -1712,6 +1712,8 @@ async def _handle_work_command(text: str) -> str:
     rest = parts[1] if len(parts) > 1 else ""
     if action in {"status"}:
         args = ["work", "status"]
+    elif action in {"reminder", "reminders"}:
+        args = ["work", "reminders"]
     elif action in {"scan", "scan_reviews", "refresh"}:
         args = ["work", "scan_reviews"]
     elif action == "show":
@@ -1754,7 +1756,7 @@ async def _handle_work_command(text: str) -> str:
             return "Use `/work done <work_id> | <result> | <evidence>`."
         args = ["work", "done", "--work-id", fields[0], "--result", fields[1], "--evidence", fields[2]]
     else:
-        return "Use `/work status|scan_reviews|show|approve|start|block|done`."
+        return "Use `/work status|reminders|scan_reviews|show|approve|start|block|done`."
 
     result = await _run_tool_router(args, timeout_sec=180)
     payload_obj = result.get("payload")
@@ -4591,6 +4593,36 @@ async def _send_owner_dashboard() -> None:
         await bot.session.close()
 
 
+async def _send_owner_work_reminders() -> bool:
+    runtime = _runtime()
+    if runtime.owner_chat_id is None:
+        raise RuntimeError("TELEGRAM_OWNER_CHAT_ID is required for --send-work-reminders.")
+
+    result = await _run_tool_router(["work", "reminders"], timeout_sec=180)
+    payload = result.get("payload")
+    if not result.get("ok") or not isinstance(payload, dict):
+        raise RuntimeError(f"Work reminder generation failed: {result.get('stderr') or 'unknown error'}")
+    if not payload.get("ok"):
+        raise RuntimeError(f"Work reminder generation failed: {payload.get('error') or 'unknown error'}")
+    if not payload.get("needs_attention"):
+        LOGGER.info("No owner work reminders to send.")
+        return False
+
+    text = str(payload.get("text") or "Work reminders need attention.").strip()
+    try:
+        import aiogram  # noqa: F401  # pylint: disable=unused-import,import-outside-toplevel
+    except ImportError as exc:
+        raise RuntimeError("aiogram is not installed. Install it before using Telegram push delivery.") from exc
+
+    bot = _build_telegram_bot(runtime.bot_token)
+    try:
+        await bot.send_message(runtime.owner_chat_id, text)
+    finally:
+        await bot.session.close()
+    LOGGER.info("Work reminders sent to chat_id=%s", runtime.owner_chat_id)
+    return True
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Async aiogram Telegram bridge for AI Holding Company.")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to projects.yaml.")
@@ -4599,6 +4631,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--simulate-chat-id", type=int, default=None, help="Optional chat id for simulation.")
     parser.add_argument("--send-morning-brief", action="store_true", help="Generate and send the morning brief.")
     parser.add_argument("--send-dashboard", action="store_true", help="Send or update the owner Telegram dashboard.")
+    parser.add_argument("--send-work-reminders", action="store_true", help="Send owner reminders for work needing attention.")
     return parser
 
 
@@ -4634,6 +4667,10 @@ async def main() -> None:
     if args.send_dashboard:
         await _send_owner_dashboard()
         print(json.dumps({"ok": True, "mode": "send_dashboard"}))
+        return
+    if args.send_work_reminders:
+        sent = await _send_owner_work_reminders()
+        print(json.dumps({"ok": True, "mode": "send_work_reminders", "sent": sent}))
         return
 
     try:

--- a/scripts/aiogram_bridge.py
+++ b/scripts/aiogram_bridge.py
@@ -1375,6 +1375,7 @@ def _format_help() -> str:
         "- /loop new <goal>\n"
         "- /loop status\n"
         "- /loop show <loop_id>\n"
+        "- /work [status|scan_reviews]\n"
         "- /brief\n"
         "- /memory <query>\n"
         "- /bot <bot_id> health|report|logs [lines]|execute [confirm]\n"
@@ -1702,6 +1703,31 @@ async def _handle_loop_command(text: str) -> str:
     if not payload_obj.get("ok"):
         return f"Loop command failed: {payload_obj.get('error') or 'unknown error'}"
     return _format_loop_payload(payload_obj)
+
+
+async def _handle_work_command(text: str) -> str:
+    payload = re.sub(r"^/work\s*", "", text, count=1, flags=re.I).strip()
+    action = payload.lower() or "status"
+    if action in {"status"}:
+        args = ["work", "status"]
+    elif action in {"scan", "scan_reviews", "refresh"}:
+        args = ["work", "scan_reviews"]
+    else:
+        return "Use `/work` or `/work scan_reviews`."
+
+    result = await _run_tool_router(args, timeout_sec=180)
+    payload_obj = result.get("payload")
+    if not result.get("ok") or not isinstance(payload_obj, dict):
+        return f"Work command failed: {result.get('stderr') or 'unknown error'}"
+    if not payload_obj.get("ok"):
+        return f"Work command failed: {payload_obj.get('error') or 'unknown error'}"
+
+    text_payload = str(payload_obj.get("text") or payload_obj).strip()
+    if args[-1] == "scan_reviews":
+        created = int(payload_obj.get("created", 0) or 0)
+        existing = int(payload_obj.get("existing", 0) or 0)
+        return f"Review scan complete: created {created}, existing {existing}.\n\n{text_payload}".strip()
+    return text_payload
 
 
 def _normalize_approval_id(raw_value: str) -> str:
@@ -3829,7 +3855,9 @@ def _command_action_type(text: str) -> str:
         return "board_approval_decision"
     if lowered.startswith("/assign") or lowered.startswith("/start") or lowered.startswith("/done"):
         return "approval_execution_update"
-    if lowered in {"/brief", "/board", "/board review", "/commercial"} or lowered.startswith(("/boardroom", "/loop")):
+    if lowered in {"/brief", "/board", "/board review", "/commercial"} or lowered.startswith(
+        ("/boardroom", "/loop", "/work")
+    ):
         return "view_status"
     if lowered == "/content_status":
         return "view_status"
@@ -3919,6 +3947,8 @@ async def _handle_known_command(text: str, user_id: int | None = None) -> str | 
         return await _handle_boardroom_command(text)
     if text.startswith("/loop"):
         return await _handle_loop_command(text)
+    if text.startswith("/work"):
+        return await _handle_work_command(text)
     if lowered == "/commercial":
         division_data = _build_division_data(text, ["commercial"])
         facts = division_data.get("context_lines", [])

--- a/scripts/aiogram_bridge.py
+++ b/scripts/aiogram_bridge.py
@@ -1375,7 +1375,7 @@ def _format_help() -> str:
         "- /loop new <goal>\n"
         "- /loop status\n"
         "- /loop show <loop_id>\n"
-        "- /work [status|reminders|scan_reviews|show|approve|start|block|done]\n"
+        "- /work [status|reminders|run_next|scan_reviews|show|approve|start|block|done]\n"
         "- /brief\n"
         "- /memory <query>\n"
         "- /bot <bot_id> health|report|logs [lines]|execute [confirm]\n"
@@ -1714,6 +1714,8 @@ async def _handle_work_command(text: str) -> str:
         args = ["work", "status"]
     elif action in {"reminder", "reminders"}:
         args = ["work", "reminders"]
+    elif action in {"run_next", "run-next"}:
+        args = ["work", "run_next"]
     elif action in {"scan", "scan_reviews", "refresh"}:
         args = ["work", "scan_reviews"]
     elif action == "show":
@@ -1756,7 +1758,7 @@ async def _handle_work_command(text: str) -> str:
             return "Use `/work done <work_id> | <result> | <evidence>`."
         args = ["work", "done", "--work-id", fields[0], "--result", fields[1], "--evidence", fields[2]]
     else:
-        return "Use `/work status|reminders|scan_reviews|show|approve|start|block|done`."
+        return "Use `/work status|reminders|run_next|scan_reviews|show|approve|start|block|done`."
 
     result = await _run_tool_router(args, timeout_sec=180)
     payload_obj = result.get("payload")
@@ -1770,6 +1772,8 @@ async def _handle_work_command(text: str) -> str:
         created = int(payload_obj.get("created", 0) or 0)
         existing = int(payload_obj.get("existing", 0) or 0)
         return f"Review scan complete: created {created}, existing {existing}.\n\n{text_payload}".strip()
+    if args[-1] == "run_next" and not payload_obj.get("ran"):
+        return str(payload_obj.get("message") or "No approved work items are ready to run.")
     item = payload_obj.get("item")
     if isinstance(item, dict):
         verb = {
@@ -1778,6 +1782,7 @@ async def _handle_work_command(text: str) -> str:
             "start": "Started",
             "block": "Blocked",
             "done": "Closed",
+            "run_next": "Worker result",
         }.get(action, "Work item")
         evidence = item.get("evidence", [])
         evidence_count = len(evidence) if isinstance(evidence, list) else 0
@@ -3907,6 +3912,12 @@ def _command_action_type(text: str) -> str:
     lowered = text.lower().strip()
     if lowered in {"/help", "/status", "/dashboard", "/hermes_status"}:
         return "view_status"
+    if lowered.startswith("/work"):
+        parts = lowered.split(maxsplit=2)
+        action = parts[1] if len(parts) > 1 else "status"
+        if action in {"approve", "start", "block", "done", "run_next", "run-next"}:
+            return "approval_execution_update"
+        return "view_status"
     if lowered.startswith("/approvals"):
         return "view_approvals"
     if lowered.startswith("/approve_merge_") or lowered.startswith("/reject_merge_"):
@@ -3917,9 +3928,7 @@ def _command_action_type(text: str) -> str:
         return "board_approval_decision"
     if lowered.startswith("/assign") or lowered.startswith("/start") or lowered.startswith("/done"):
         return "approval_execution_update"
-    if lowered in {"/brief", "/board", "/board review", "/commercial"} or lowered.startswith(
-        ("/boardroom", "/loop", "/work")
-    ):
+    if lowered in {"/brief", "/board", "/board review", "/commercial"} or lowered.startswith(("/boardroom", "/loop")):
         return "view_status"
     if lowered == "/content_status":
         return "view_status"
@@ -4623,6 +4632,43 @@ async def _send_owner_work_reminders() -> bool:
     return True
 
 
+async def _run_next_work_and_notify_owner() -> bool:
+    runtime = _runtime()
+    if runtime.owner_chat_id is None:
+        raise RuntimeError("TELEGRAM_OWNER_CHAT_ID is required for --run-work-next.")
+
+    result = await _run_tool_router(["work", "run_next"], timeout_sec=180)
+    payload = result.get("payload")
+    if not result.get("ok") or not isinstance(payload, dict):
+        raise RuntimeError(f"Work runner failed: {result.get('stderr') or 'unknown error'}")
+    if not payload.get("ok"):
+        raise RuntimeError(f"Work runner failed: {payload.get('error') or 'unknown error'}")
+    if not payload.get("ran"):
+        LOGGER.info("No approved work item was ready to run.")
+        return False
+
+    item = payload.get("item", {})
+    item = item if isinstance(item, dict) else {}
+    text = (
+        f"Work runner: {payload.get('outcome')} for `{item.get('id')}` [{item.get('status')}]\n"
+        f"Title: {item.get('title')}\n"
+        f"Owner: {item.get('owner')} | Due: {item.get('due_at') or 'n/a'}\n"
+        f"Next: {item.get('next_step')}"
+    )
+    try:
+        import aiogram  # noqa: F401  # pylint: disable=unused-import,import-outside-toplevel
+    except ImportError as exc:
+        raise RuntimeError("aiogram is not installed. Install it before using Telegram push delivery.") from exc
+
+    bot = _build_telegram_bot(runtime.bot_token)
+    try:
+        await bot.send_message(runtime.owner_chat_id, text)
+    finally:
+        await bot.session.close()
+    LOGGER.info("Work runner result sent to chat_id=%s", runtime.owner_chat_id)
+    return True
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Async aiogram Telegram bridge for AI Holding Company.")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to projects.yaml.")
@@ -4632,6 +4678,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--send-morning-brief", action="store_true", help="Generate and send the morning brief.")
     parser.add_argument("--send-dashboard", action="store_true", help="Send or update the owner Telegram dashboard.")
     parser.add_argument("--send-work-reminders", action="store_true", help="Send owner reminders for work needing attention.")
+    parser.add_argument("--run-work-next", action="store_true", help="Run the next approved work item and notify the owner.")
     return parser
 
 
@@ -4671,6 +4718,10 @@ async def main() -> None:
     if args.send_work_reminders:
         sent = await _send_owner_work_reminders()
         print(json.dumps({"ok": True, "mode": "send_work_reminders", "sent": sent}))
+        return
+    if args.run_work_next:
+        sent = await _run_next_work_and_notify_owner()
+        print(json.dumps({"ok": True, "mode": "run_work_next", "sent": sent}))
         return
 
     try:

--- a/scripts/aiogram_bridge.py
+++ b/scripts/aiogram_bridge.py
@@ -1376,6 +1376,12 @@ def _format_help() -> str:
         "- /loop status\n"
         "- /loop show <loop_id>\n"
         "- /work [status|reminders|run_next|scan_reviews|show|approve|start|block|done]\n"
+        "- /ask_company <question>\n"
+        "- /risk_aggregate_daily\n"
+        "- /data_quality_daily\n"
+        "- /backtest_review\n"
+        "- /support_triage\n"
+        "- /portfolio_retro_weekly\n"
         "- /brief\n"
         "- /memory <query>\n"
         "- /bot <bot_id> health|report|logs [lines]|execute [confirm]\n"
@@ -1386,6 +1392,50 @@ def _format_help() -> str:
 def _brief_preview(text: str, limit: int = 100) -> str:
     clean = " ".join(text.split())
     return clean if len(clean) <= limit else f"{clean[:limit].rstrip()}..."
+
+
+def _format_agent_skill_payload(payload: dict[str, Any]) -> str:
+    skill = str(payload.get("skill") or "skill").strip()
+    status = str(payload.get("status") or "UNKNOWN").strip()
+    brief = str(payload.get("brief") or "").strip()
+    owner_need = str(payload.get("owner_need") or "none").strip()
+    artifact = str(payload.get("markdown_path") or payload.get("json_path") or "").strip()
+    lines = [f"{skill} is {status}."]
+    if brief:
+        lines.append(brief)
+    lines.append(f"Owner need: {owner_need}")
+    if artifact:
+        lines.append(f"Artifact: `{artifact}`")
+    return "\n".join(lines)
+
+
+async def _handle_ask_company_command(text: str) -> str:
+    question = re.sub(r"^/ask_company\s*", "", text, count=1, flags=re.I).strip()
+    if not question:
+        return "Use `/ask_company <question>`."
+    result = await _run_tool_router(["ask_company", "--question", question, "--json"], timeout_sec=120)
+    payload = result.get("payload")
+    if not result.get("ok") or not isinstance(payload, dict):
+        return f"Chief of Staff command failed: {result.get('stderr') or 'unknown error'}"
+    answer = str(payload.get("answer") or "").strip()
+    if not answer:
+        return "I do not have enough stored company evidence to answer that yet."
+    owner_need = str(payload.get("owner_need") or "none").strip()
+    sources = payload.get("sources", [])
+    source_text = ""
+    if isinstance(sources, list) and sources:
+        source_text = "\nSources: " + ", ".join(str(source) for source in sources)
+    return f"{answer}\nOwner need: {owner_need}{source_text}"
+
+
+async def _handle_agent_skill_command(command: str) -> str:
+    result = await _run_tool_router([command], timeout_sec=180)
+    payload = result.get("payload")
+    if not result.get("ok") or not isinstance(payload, dict):
+        return f"Agent skill command failed: {result.get('stderr') or 'unknown error'}"
+    if not payload.get("ok"):
+        return f"Agent skill command failed: {payload.get('error') or 'unknown error'}"
+    return _format_agent_skill_payload(payload)
 
 
 async def _handle_content_command(brief_text: str) -> str:
@@ -3944,6 +3994,16 @@ def _command_action_type(text: str) -> str:
         return "develop_submit"
     if lowered.startswith("/memory"):
         return "memory_query"
+    if lowered.startswith("/ask_company"):
+        return "view_status"
+    if lowered in {
+        "/risk_aggregate_daily",
+        "/data_quality_daily",
+        "/backtest_review",
+        "/support_triage",
+        "/portfolio_retro_weekly",
+    }:
+        return "view_status"
     if lowered.startswith("/bot "):
         return "bot_execute" if " execute" in lowered else "view_status"
     if lowered.startswith("/site ") or lowered.startswith("/divisions"):
@@ -4020,6 +4080,16 @@ async def _handle_known_command(text: str, user_id: int | None = None) -> str | 
         return await _handle_loop_command(text)
     if text.startswith("/work"):
         return await _handle_work_command(text)
+    if text.startswith("/ask_company"):
+        return await _handle_ask_company_command(text)
+    if lowered in {
+        "/risk_aggregate_daily",
+        "/data_quality_daily",
+        "/backtest_review",
+        "/support_triage",
+        "/portfolio_retro_weekly",
+    }:
+        return await _handle_agent_skill_command(lowered.lstrip("/"))
     if lowered == "/commercial":
         division_data = _build_division_data(text, ["commercial"])
         facts = division_data.get("context_lines", [])

--- a/scripts/chief_of_staff.py
+++ b/scripts/chief_of_staff.py
@@ -1,0 +1,195 @@
+"""Natural, truth-grounded Chief of Staff answers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from org_truth_retriever import ROOT, TruthBundle, collect_truth_bundle
+
+
+def _plural(count: int, singular: str, plural: str | None = None) -> str:
+    word = singular if count == 1 else (plural or f"{singular}s")
+    number = "one" if count == 1 else str(count)
+    return f"{number} {word}"
+
+
+def _approval_phrase(bundle: TruthBundle) -> str:
+    if not bundle.pending_approvals:
+        return "I do not see a pending owner approval in the current approval snapshot."
+    first = bundle.pending_approvals[0]
+    topic = str(first.get("topic") or first.get("approval_id") or "approval").strip()
+    return f"You have {_plural(len(bundle.pending_approvals), 'approval')} waiting, led by {topic}."
+
+
+def _first_approval_topic(bundle: TruthBundle) -> str:
+    if not bundle.pending_approvals:
+        return ""
+    first = bundle.pending_approvals[0]
+    return str(first.get("topic") or first.get("approval_id") or "approval").strip()
+
+
+def _status_reason(bundle: TruthBundle) -> str:
+    if bundle.company_risks:
+        return bundle.company_risks[0]
+    if bundle.company_actions:
+        return bundle.company_actions[0]
+    return "The latest scorecard does not include a specific risk note."
+
+
+def _answer_owner_needs(bundle: TruthBundle) -> tuple[str, str]:
+    if bundle.truth_state == "unknown":
+        return (
+            "I do not have current company evidence yet. Refresh the company reports before I tell you what needs the owner.",
+            "refresh",
+        )
+
+    parts: list[str] = []
+    if bundle.pending_approvals:
+        topic = _first_approval_topic(bundle)
+        parts.append(f"You have one real decision today: {topic}.")
+        parts.append(f"That is {_plural(len(bundle.pending_approvals), 'approval')} waiting in the current snapshot.")
+    else:
+        parts.append(
+            f"You're clear on approvals right now. The company is {bundle.company_status} in the latest stored CEO report."
+        )
+
+    parts.append(_status_reason(bundle))
+    if bundle.approved_awaiting_execution:
+        parts.append(
+            f"There are also {_plural(len(bundle.approved_awaiting_execution), 'approved item')} waiting for execution follow-through, which is likely the operating drag to clean up next."
+        )
+    owner_need = "approve" if bundle.pending_approvals else "none"
+    return " ".join(parts), owner_need
+
+
+def _format_issue(issue: dict[str, Any]) -> str:
+    metric = str(issue.get("metric") or "Trading issue").strip()
+    actual = str(issue.get("actual") or "").strip()
+    target = str(issue.get("target") or "").strip()
+    details = ""
+    if actual or target:
+        details = f" ({actual} vs {target})".replace(" vs )", ")")
+    action = str(issue.get("action") or "").strip()
+    if action:
+        return f"{metric}{details}; next step is {action}"
+    return f"{metric}{details}"
+
+
+def _answer_trading(bundle: TruthBundle) -> tuple[str, str]:
+    if bundle.data_quality_status not in {"", "UNKNOWN"}:
+        if bundle.data_quality_status != "GREEN" or bundle.trading_status == "UNKNOWN":
+            detail = bundle.data_quality_brief or "The latest data-quality skill output is available."
+            return (f"Trading data-quality readiness is {bundle.data_quality_status}. {detail}", "none")
+    if bundle.trading_status == "UNKNOWN":
+        return (
+            "I do not have current trading evidence in the stored division reports. Treat trading status as unknown until the trading readiness reports are refreshed.",
+            "refresh",
+        )
+    if not bundle.trading_issues:
+        return (f"Trading is {bundle.trading_status}. I do not see an open AMBER or RED trading issue in the current scorecard.", "none")
+    issue_text = _format_issue(bundle.trading_issues[0])
+    return (f"Trading is {bundle.trading_status} because of {issue_text}.", "none")
+
+
+def _answer_strategy_review(bundle: TruthBundle) -> tuple[str, str]:
+    if bundle.backtest_review_status not in {"", "UNKNOWN"}:
+        answer = bundle.backtest_review_brief or f"Backtest review is {bundle.backtest_review_status}."
+        if bundle.backtest_review_next_action:
+            answer = f"{answer} {bundle.backtest_review_next_action}"
+        owner_need = "approve" if bundle.backtest_review_status == "PASS_FOR_OWNER_APPROVAL" else "none"
+        return answer, owner_need
+    return _answer_trading(bundle)
+
+
+def _answer_support(bundle: TruthBundle) -> tuple[str, str]:
+    if bundle.support_triage_status not in {"", "UNKNOWN"}:
+        detail = bundle.support_triage_brief or "The latest support triage artifact is available."
+        owner_need = "approve" if bundle.support_triage_status == "AMBER" else "none"
+        if detail.lower().startswith("support triage is "):
+            return detail, owner_need
+        return f"Support triage is {bundle.support_triage_status}. {detail}", owner_need
+    return (
+        "I do not have a support triage artifact yet. Support is only knowable after a local ticket source is wired or scanned.",
+        "refresh",
+    )
+
+
+def _answer_blockers(bundle: TruthBundle) -> tuple[str, str]:
+    blockers: list[str] = []
+    for approval in bundle.pending_approvals:
+        topic = str(approval.get("topic") or approval.get("approval_id") or "approval").strip()
+        blockers.append(f"owner approval for {topic}")
+    for issue in bundle.trading_issues[:2]:
+        blockers.append(_format_issue(issue))
+    if not blockers:
+        if bundle.truth_state == "unknown":
+            return ("I do not have current evidence to identify blockers yet.", "refresh")
+        return ("I do not see a stored blocker in the current reports and approval state.", "none")
+    return "The main blocker is " + "; ".join(blockers) + ".", "approve" if bundle.pending_approvals else "none"
+
+
+def answer_company_question(question: str, root: Path | str = ROOT) -> dict[str, Any]:
+    """Answer a company question from durable local truth only."""
+
+    bundle = collect_truth_bundle(root)
+    normalized = question.lower().strip()
+
+    if any(term in normalized for term in ("backtest", "forward-test", "forward test", "strategy")):
+        answer, owner_need = _answer_strategy_review(bundle)
+    elif any(term in normalized for term in ("support", "ticket", "customer")):
+        answer, owner_need = _answer_support(bundle)
+    elif "trading" in normalized:
+        answer, owner_need = _answer_trading(bundle)
+    elif any(term in normalized for term in ("blocked", "blocker", "stuck")):
+        answer, owner_need = _answer_blockers(bundle)
+    else:
+        answer, owner_need = _answer_owner_needs(bundle)
+
+    if any(term in normalized for term in ("show evidence", "sources", "source", "evidence")):
+        sources = bundle.source_paths()
+        if sources:
+            answer = f"{answer} Evidence: " + ", ".join(sources) + "."
+        else:
+            answer = f"{answer} I do not have source files to cite yet."
+
+    return {
+        "ok": True,
+        "question": question,
+        "answer": answer,
+        "owner_need": owner_need,
+        "truth_state": bundle.truth_state,
+        "sources": bundle.source_paths(),
+    }
+
+
+def render_company_answer(response: dict[str, Any]) -> str:
+    """Render the Chief of Staff answer for humans."""
+
+    answer = str(response.get("answer") or "").strip()
+    if not answer:
+        return "I do not have enough stored company evidence to answer that yet."
+    return answer
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ask the truth-grounded Chief of Staff.")
+    parser.add_argument("--question", required=True, help="Natural owner question.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root for truth retrieval.")
+    parser.add_argument("--json", action="store_true", help="Print structured JSON instead of conversational text.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    response = answer_company_question(args.question, root=Path(args.root))
+    if args.json:
+        print(json.dumps(response, indent=2))
+    else:
+        print(render_company_answer(response))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/company_loop.py
+++ b/scripts/company_loop.py
@@ -162,6 +162,8 @@ def _markdown_for_loop(loop: dict[str, Any]) -> str:
     evidence = evidence if isinstance(evidence, list) else []
     history = loop.get("history", [])
     history = history if isinstance(history, list) else []
+    execution_plan = loop.get("execution_plan", [])
+    execution_plan = execution_plan if isinstance(execution_plan, list) else []
     lines = [
         f"# Company Loop {loop.get('loop_id')}",
         "",
@@ -187,6 +189,22 @@ def _markdown_for_loop(loop: dict[str, Any]) -> str:
             lines.append(f"- {path or 'evidence'}{suffix}")
     else:
         lines.append("- None yet.")
+    lines.extend(["", "## Execution Plan"])
+    if execution_plan:
+        for item in execution_plan:
+            if not isinstance(item, dict):
+                continue
+            task = str(item.get("task", "")).strip() or "Untitled task"
+            owner = str(item.get("owner", "")).strip() or "Unassigned"
+            due = str(item.get("due_at_utc", "")).strip() or "No due date"
+            status = str(item.get("status", "")).strip() or "TODO"
+            completion = str(item.get("completion_signal", "")).strip() or "Completion evidence not defined."
+            lines.append(f"- [{status}] {task}")
+            lines.append(f"  Owner: {owner}")
+            lines.append(f"  Due UTC: {due}")
+            lines.append(f"  Completion signal: {completion}")
+    else:
+        lines.append("- None defined.")
     lines.extend(
         [
             "",
@@ -283,6 +301,7 @@ def new_loop(
         "measurement_plan": "",
         "result": "",
         "next_step": "Gather evidence and prepare division review.",
+        "execution_plan": [],
         "history": [{"timestamp_utc": now, "event": "GOAL_CAPTURED", "note": "Loop created."}],
     }
     if _needs_approval(loop):

--- a/scripts/nanoclaw_shadow_writer.py
+++ b/scripts/nanoclaw_shadow_writer.py
@@ -1,0 +1,103 @@
+"""Local NanoClaw shadow writer simulator.
+
+This does not call NanoClaw or any external model. It consumes the local
+truth-packet inbox and writes a candidate response in the same shape expected
+from a future NanoClaw verbalizer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INBOX = "state/nanoclaw_shadow_inbox.jsonl"
+DEFAULT_OUTBOX = "state/nanoclaw_shadow_outbox.jsonl"
+
+
+def _latest_inbox_record(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and isinstance(payload.get("packet"), dict):
+            return payload
+    return {}
+
+
+def _brief_answer(packet: dict[str, Any]) -> str:
+    persona = str(packet.get("persona") or "")
+    intent = str(packet.get("intent") or "")
+    evidence = packet.get("evidence", [])
+    if intent == "role" and persona == "chief-of-staff":
+        return "I help you run the company by keeping attention, blockers, approvals, and evidence visible."
+    if evidence:
+        lead = evidence[0]
+        brief = str(lead.get("brief") or "")
+        return f"I would start here: {brief}"
+    unknowns = packet.get("unknowns", [])
+    if unknowns:
+        return str(unknowns[0])
+    return "I do not see a stored issue needing you right now."
+
+
+def write_latest_shadow_response(
+    root: Path | str = ROOT,
+    inbox_path: str = DEFAULT_INBOX,
+    outbox_path: str = DEFAULT_OUTBOX,
+) -> dict[str, Any]:
+    """Write a local shadow response for the latest truth packet."""
+
+    root_path = Path(root)
+    record = _latest_inbox_record(root_path / inbox_path)
+    if not record:
+        return {"ok": False, "error": "no_inbox_record"}
+    packet = record["packet"]
+    output = {
+        "packet_id": packet.get("packet_id"),
+        "persona": packet.get("persona"),
+        "intent": packet.get("intent"),
+        "answer": _brief_answer(packet),
+        "unsupported_claims": [],
+        "confidence": "medium",
+        "source": "local_shadow_writer",
+    }
+    output_file = root_path / outbox_path
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with output_file.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(output, sort_keys=True) + "\n")
+    return {"ok": True, "packet_id": output["packet_id"], "outbox_path": outbox_path}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Write a local NanoClaw shadow response from the latest inbox packet.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    parser.add_argument("--inbox-path", default=DEFAULT_INBOX, help="Relative shadow inbox path.")
+    parser.add_argument("--outbox-path", default=DEFAULT_OUTBOX, help="Relative shadow outbox path.")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    result = write_latest_shadow_response(
+        root=Path(args.root),
+        inbox_path=args.inbox_path,
+        outbox_path=args.outbox_path,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nanoclaw_status.py
+++ b/scripts/nanoclaw_status.py
@@ -1,0 +1,116 @@
+"""Report NanoClaw live acceptance rates per persona.
+
+Reads the live-mode decision log (one JSON record per attempt) and prints a
+per-persona accept rate over the configured window. Used by the owner to
+decide when a persona is safe to promote from shadow to live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_log(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    except OSError:
+        return []
+    return rows
+
+
+def compute_status(
+    log_path: Path,
+    window: int,
+    min_accept_rate: float,
+    personas: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    rows = _read_log(log_path)
+    by_persona: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        persona = str(row.get("persona") or "")
+        if not persona:
+            continue
+        by_persona.setdefault(persona, []).append(row)
+
+    out_personas: list[dict[str, Any]] = []
+    seen = set()
+    for persona, records in sorted(by_persona.items()):
+        window_records = records[-window:]
+        accepted = sum(1 for r in window_records if r.get("accepted"))
+        total = len(window_records)
+        rate = (accepted / total) if total else 0.0
+        out_personas.append({
+            "persona": persona,
+            "current_mode": (personas or {}).get(persona, "unknown"),
+            "window_size": total,
+            "accepted": accepted,
+            "accept_rate": round(rate, 4),
+            "meets_gate": total >= window and rate >= min_accept_rate,
+        })
+        seen.add(persona)
+
+    if personas:
+        for persona, mode in sorted(personas.items()):
+            if persona in seen:
+                continue
+            out_personas.append({
+                "persona": persona,
+                "current_mode": mode,
+                "window_size": 0,
+                "accepted": 0,
+                "accept_rate": 0.0,
+                "meets_gate": False,
+            })
+
+    return {
+        "ok": True,
+        "log_path": str(log_path),
+        "window": window,
+        "min_accept_rate": min_accept_rate,
+        "personas": out_personas,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Show NanoClaw live acceptance rate per persona.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    parser.add_argument("--config", default=None, help="Path to projects.yaml.")
+    return parser
+
+
+def main() -> None:
+    from monitoring import load_config  # pylint: disable=import-outside-toplevel
+
+    args = _build_parser().parse_args()
+    root = Path(args.root)
+    config_path = Path(args.config) if args.config else root / "config" / "projects.yaml"
+    config = load_config(config_path)
+    nanoclaw_cfg = (config.get("conversation", {}) or {}).get("nanoclaw", {}) or {}
+    log_path = root / str(nanoclaw_cfg.get("live_log_path") or "state/nanoclaw_live_log.jsonl")
+    promotion = nanoclaw_cfg.get("promotion", {}) or {}
+    window = int(promotion.get("window") or 50)
+    min_rate = float(promotion.get("min_accept_rate") or 0.80)
+    personas = nanoclaw_cfg.get("personas", {}) or {}
+    result = compute_status(log_path, window=window, min_accept_rate=min_rate, personas=personas)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operating_room_server.py
+++ b/scripts/operating_room_server.py
@@ -1,0 +1,121 @@
+"""Local-only operating room server with persona chat endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from monitoring import load_config
+from nanoclaw_shadow_writer import write_latest_shadow_response
+from persona_router import answer_persona
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC_ROOT = ROOT / "operating-room"
+CONFIG_PATH = ROOT / "config" / "projects.yaml"
+
+
+def _json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, indent=2).encode("utf-8")
+
+
+class OperatingRoomHandler(BaseHTTPRequestHandler):
+    """Serve the local operating room and deterministic persona chat."""
+
+    server_version = "OperatingRoom/0.1"
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path in {"/", "/operating-room", "/operating-room/"}:
+            self._serve_static(STATIC_ROOT / "index.html")
+            return
+        if self.path.startswith("/operating-room/"):
+            rel_path = self.path.removeprefix("/operating-room/")
+            self._serve_static(STATIC_ROOT / rel_path)
+            return
+        if self.path == "/snapshot.json":
+            self._serve_static(STATIC_ROOT / "snapshot.json")
+            return
+        self._send_json({"ok": False, "error": "not found"}, status=HTTPStatus.NOT_FOUND)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/api/nanoclaw-shadow-write":
+            self._send_json(write_latest_shadow_response(root=ROOT))
+            return
+        if self.path != "/api/persona-chat":
+            self._send_json({"ok": False, "error": "not found"}, status=HTTPStatus.NOT_FOUND)
+            return
+        payload = self._read_json_body()
+        persona = str(payload.get("persona") or "chief-of-staff")
+        message = str(payload.get("message") or "").strip()
+        if not message:
+            self._send_json({"ok": False, "error": "message is required"}, status=HTTPStatus.BAD_REQUEST)
+            return
+        config = load_config(CONFIG_PATH)
+        self._send_json(
+            answer_persona(
+                persona=persona,
+                message=message,
+                root=ROOT,
+                conversation_config=config.get("conversation", {}),
+            )
+        )
+
+    def _read_json_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("content-length") or "0")
+        if length <= 0:
+            return {}
+        try:
+            payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _serve_static(self, path: Path) -> None:
+        resolved = path.resolve()
+        if STATIC_ROOT.resolve() not in resolved.parents and resolved != STATIC_ROOT.resolve():
+            self._send_json({"ok": False, "error": "invalid path"}, status=HTTPStatus.BAD_REQUEST)
+            return
+        if not resolved.exists() or not resolved.is_file():
+            self._send_json({"ok": False, "error": "file not found"}, status=HTTPStatus.NOT_FOUND)
+            return
+        content_type = mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
+        body = resolved.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = _json_bytes(payload)
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the local operating room server.")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host. Defaults to localhost only.")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port.")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), OperatingRoomHandler)
+    print(f"Operating room listening on http://{args.host}:{args.port}/operating-room/")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operating_room_snapshot.py
+++ b/scripts/operating_room_snapshot.py
@@ -1,0 +1,226 @@
+"""Build a deterministic read-only operating room snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PERSONAS = [
+    {
+        "name": "Chief of Staff",
+        "slug": "chief-of-staff",
+        "grounding": "Reads company-level risk, approvals, current skill outputs, and retros.",
+        "contract": "docs/personas/chief-of-staff/contract.md",
+    },
+    {
+        "name": "Risk Officer",
+        "slug": "risk-officer",
+        "grounding": "Reads guardrail artifacts, risk blocks, and approval state.",
+        "contract": "docs/personas/risk-officer/contract.md",
+    },
+    {
+        "name": "Quant Ops",
+        "slug": "quant-ops",
+        "grounding": "Reads trading data-quality, backtest-review, and broker-reconcile artifacts.",
+        "contract": "docs/personas/quant-ops/contract.md",
+    },
+    {
+        "name": "Growth Lead",
+        "slug": "growth-lead",
+        "grounding": "Reads website analytics, growth digests, and portfolio retro evidence.",
+        "contract": "docs/personas/growth-lead/contract.md",
+    },
+    {
+        "name": "Editorial Lead",
+        "slug": "editorial-lead",
+        "grounding": "Reads content queue, draft, SEO, and analytics evidence when present.",
+        "contract": "docs/personas/editorial-lead/contract.md",
+    },
+    {
+        "name": "Engineering/Ops",
+        "slug": "engineering-ops",
+        "grounding": "Reads operating briefs, reliability records, and deploy/incident evidence.",
+        "contract": "docs/personas/engineering-ops/contract.md",
+    },
+    {
+        "name": "Support Lead",
+        "slug": "support-lead",
+        "grounding": "Reads support-triage output and local ticket sources when present.",
+        "contract": "docs/personas/support-lead/contract.md",
+    },
+    {
+        "name": "Finance/Admin",
+        "slug": "finance-admin",
+        "grounding": "Deferred until reliable finance and admin sources exist.",
+        "contract": "docs/personas/finance-admin/contract.md",
+    },
+]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_jsonl_sample(path: Path, limit: int = 8) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            rows.append(payload)
+        if len(rows) >= limit:
+            break
+    rows.reverse()
+    return rows
+
+
+def _latest_skill_outputs(root: Path) -> list[dict[str, Any]]:
+    skills_dir = root / "reports" / "skills"
+    if not skills_dir.exists():
+        return []
+    outputs: list[dict[str, Any]] = []
+    for path in sorted(skills_dir.glob("*/latest.json")):
+        payload = _read_json(path)
+        if not payload:
+            continue
+        outputs.append(
+            {
+                "skill": str(payload.get("skill") or path.parent.name),
+                "status": str(payload.get("status") or "UNKNOWN").upper(),
+                "owner_need": str(payload.get("owner_need") or "none"),
+                "brief": str(payload.get("brief") or ""),
+                "source": str(path.relative_to(root)).replace("\\", "/"),
+            }
+        )
+    return outputs
+
+
+def _approval_view(root: Path) -> dict[str, Any]:
+    payload = _read_json(root / "state" / "board_approval_decisions.json")
+    snapshot = payload.get("board_snapshot", {})
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    raw_approvals = snapshot.get("approvals", [])
+    approvals = raw_approvals if isinstance(raw_approvals, list) else []
+    pending = []
+    for item in approvals:
+        if not isinstance(item, dict):
+            continue
+        pending.append(
+            {
+                "approval_id": str(item.get("approval_id") or ""),
+                "topic": str(item.get("topic") or "approval"),
+                "priority": str(item.get("priority") or "UNKNOWN").upper(),
+                "decision": str(item.get("decision") or ""),
+            }
+        )
+    return {
+        "pending_count": len(pending),
+        "pending": pending,
+        "source": "state/board_approval_decisions.json" if payload else "",
+    }
+
+
+def _today_view(skill_outputs: list[dict[str, Any]]) -> dict[str, Any]:
+    if not skill_outputs:
+        return {
+            "status": "UNKNOWN",
+            "items": [
+                {
+                    "skill": "operating-room",
+                    "status": "UNKNOWN",
+                    "brief": "No skill outputs found under reports/skills/.",
+                    "source": "",
+                }
+            ],
+        }
+    status_order = {"BLOCKED": 0, "RED": 1, "AMBER": 2, "YELLOW": 2, "GREEN": 3}
+    sorted_items = sorted(skill_outputs, key=lambda item: status_order.get(item["status"], 4))
+    return {"status": sorted_items[0]["status"], "items": sorted_items}
+
+
+def _memory_view(root: Path) -> dict[str, Any]:
+    rows = _read_jsonl_sample(root / "memory" / "vector_store.jsonl")
+    samples = []
+    for row in rows:
+        samples.append(
+            {
+                "text": str(row.get("text") or row.get("content") or "")[:240],
+                "metadata": row.get("metadata", {}) if isinstance(row.get("metadata", {}), dict) else {},
+            }
+        )
+    return {
+        "sample_count": len(samples),
+        "samples": samples,
+        "source": "memory/vector_store.jsonl" if samples else "",
+    }
+
+
+def _personas_view(root: Path) -> dict[str, Any]:
+    personas = []
+    for persona in PERSONAS:
+        contract_path = root / persona["contract"]
+        personas.append(
+            {
+                **persona,
+                "status": "ready" if contract_path.exists() else "missing_contract",
+                "deterministic_grounding": True,
+            }
+        )
+    return {"personas": personas}
+
+
+def build_operating_room_snapshot(root: Path | str = ROOT) -> dict[str, Any]:
+    """Build and persist the read-only operating room snapshot."""
+
+    root_path = Path(root)
+    skill_outputs = _latest_skill_outputs(root_path)
+    snapshot = {
+        "ok": True,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "read_only": True,
+        "rule": "Persona chat is free text, then deterministic grounding against local truth; no model calls.",
+        "views": {
+            "today": _today_view(skill_outputs),
+            "approvals": _approval_view(root_path),
+            "memory": _memory_view(root_path),
+            "personas": _personas_view(root_path),
+        },
+    }
+    output_path = root_path / "operating-room" / "snapshot.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+    return snapshot
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build the read-only operating room snapshot.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(build_operating_room_snapshot(root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/org_truth_retriever.py
+++ b/scripts/org_truth_retriever.py
@@ -1,0 +1,213 @@
+"""Retrieve durable company truth for Chief of Staff answers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class TruthSource:
+    path: str
+    exists: bool
+    generated_at_utc: str = ""
+    truth_state: str = "unknown"
+
+
+@dataclass
+class TruthBundle:
+    truth_state: str = "unknown"
+    company_status: str = "UNKNOWN"
+    generated_at_utc: str = ""
+    company_risks: list[str] = field(default_factory=list)
+    company_actions: list[str] = field(default_factory=list)
+    base_summary: dict[str, Any] = field(default_factory=dict)
+    pending_approvals: list[dict[str, Any]] = field(default_factory=list)
+    approved_awaiting_execution: list[dict[str, Any]] = field(default_factory=list)
+    trading_status: str = "UNKNOWN"
+    trading_issues: list[dict[str, Any]] = field(default_factory=list)
+    trading_actions: list[str] = field(default_factory=list)
+    data_quality_status: str = "UNKNOWN"
+    data_quality_brief: str = ""
+    backtest_review_status: str = "UNKNOWN"
+    backtest_review_brief: str = ""
+    backtest_review_next_action: str = ""
+    website_status: str = "UNKNOWN"
+    website_issues: list[dict[str, Any]] = field(default_factory=list)
+    support_triage_status: str = "UNKNOWN"
+    support_triage_brief: str = ""
+    sources: list[TruthSource] = field(default_factory=list)
+
+    def source_paths(self) -> list[str]:
+        return [source.path for source in self.sources if source.exists]
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _source(root: Path, relative_path: str, payload: dict[str, Any] | None) -> TruthSource:
+    return TruthSource(
+        path=relative_path.replace("\\", "/"),
+        exists=(root / relative_path).exists(),
+        generated_at_utc=str((payload or {}).get("generated_at_utc", "")).strip(),
+        truth_state="known" if payload else "unknown",
+    )
+
+
+def _scorecard_items(scorecard: dict[str, Any]) -> list[dict[str, Any]]:
+    items = scorecard.get("items", [])
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _scorecard_text_list(scorecard: dict[str, Any], key: str) -> list[str]:
+    values = scorecard.get(key, [])
+    if not isinstance(values, list):
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def _extract_pending_approvals(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    snapshot = payload.get("board_snapshot", {})
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    approvals = snapshot.get("approvals", [])
+    if not isinstance(approvals, list):
+        return []
+    return [item for item in approvals if isinstance(item, dict)]
+
+
+def _extract_approved_execution(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    phase3_snapshot = payload.get("approval_execution_snapshot", {})
+    if isinstance(phase3_snapshot, dict):
+        approved = phase3_snapshot.get("approved_awaiting_execution", [])
+        if isinstance(approved, list):
+            return [item for item in approved if isinstance(item, dict)]
+
+    execution = payload.get("execution_by_approval", {})
+    if not isinstance(execution, dict):
+        return []
+    open_rows: list[dict[str, Any]] = []
+    for approval_id, row in execution.items():
+        if not isinstance(row, dict):
+            continue
+        status = str(row.get("status", "")).upper()
+        if status in {"APPROVED", "ASSIGNED", "STARTED"}:
+            clean_row = dict(row)
+            clean_row["approval_id"] = str(approval_id)
+            open_rows.append(clean_row)
+    return open_rows
+
+
+def _extract_division(
+    phase2_payload: dict[str, Any] | None,
+    division_name: str,
+) -> tuple[str, list[dict[str, Any]], list[str]]:
+    if not isinstance(phase2_payload, dict):
+        return "UNKNOWN", [], []
+    divisions = phase2_payload.get("divisions", [])
+    if not isinstance(divisions, list):
+        return "UNKNOWN", [], []
+    for division in divisions:
+        if not isinstance(division, dict):
+            continue
+        if str(division.get("division", "")).lower() != division_name:
+            continue
+        scorecard = division.get("scorecard", {})
+        scorecard = scorecard if isinstance(scorecard, dict) else {}
+        status = str(scorecard.get("status") or division.get("status") or "UNKNOWN").upper()
+        issues = [
+            item
+            for item in _scorecard_items(scorecard)
+            if str(item.get("status", "")).upper() in {"AMBER", "RED", "YELLOW", "BLOCKED"}
+        ]
+        actions = _scorecard_text_list(scorecard, "actions")
+        return status, issues, actions
+    return "UNKNOWN", [], []
+
+
+def collect_truth_bundle(root: Path | str = ROOT) -> TruthBundle:
+    """Collect current first-party truth without external calls."""
+
+    root_path = Path(root)
+    phase3_rel = "reports/phase3_holding_latest.json"
+    phase2_rel = "reports/phase2_divisions_latest.json"
+    daily_rel = "reports/daily_brief_latest.json"
+    approvals_rel = "state/board_approval_decisions.json"
+    data_quality_rel = "reports/skills/data-quality-daily/latest.json"
+    backtest_review_rel = "reports/skills/backtest-review/latest.json"
+    support_triage_rel = "reports/skills/support-triage/latest.json"
+
+    phase3 = _load_json(root_path / phase3_rel)
+    phase2 = _load_json(root_path / phase2_rel)
+    daily = _load_json(root_path / daily_rel)
+    approvals = _load_json(root_path / approvals_rel)
+    data_quality = _load_json(root_path / data_quality_rel)
+    backtest_review = _load_json(root_path / backtest_review_rel)
+    support_triage = _load_json(root_path / support_triage_rel)
+
+    scorecard = phase3.get("company_scorecard", {}) if isinstance(phase3, dict) else {}
+    scorecard = scorecard if isinstance(scorecard, dict) else {}
+    company_status = str(scorecard.get("status") or "UNKNOWN").upper()
+    truth_state = (
+        "known"
+        if phase3 or phase2 or daily or approvals or data_quality or backtest_review or support_triage
+        else "unknown"
+    )
+
+    trading_status, trading_issues, trading_actions = _extract_division(phase2, "trading")
+    website_status, website_issues, _website_actions = _extract_division(phase2, "websites")
+
+    approved_execution = _extract_approved_execution(phase3)
+    if not approved_execution:
+        approved_execution = _extract_approved_execution(approvals)
+
+    return TruthBundle(
+        truth_state=truth_state,
+        company_status=company_status,
+        generated_at_utc=str((phase3 or {}).get("generated_at_utc", "")).strip(),
+        company_risks=_scorecard_text_list(scorecard, "risks"),
+        company_actions=_scorecard_text_list(scorecard, "actions"),
+        base_summary=(phase3 or daily or {}).get("base_summary", {})
+        if isinstance((phase3 or daily or {}).get("base_summary", {}), dict)
+        else {},
+        pending_approvals=_extract_pending_approvals(approvals),
+        approved_awaiting_execution=approved_execution,
+        trading_status=trading_status,
+        trading_issues=trading_issues,
+        trading_actions=trading_actions,
+        data_quality_status=str((data_quality or {}).get("status", "UNKNOWN")).upper(),
+        data_quality_brief=str((data_quality or {}).get("brief", "")).strip(),
+        backtest_review_status=str((backtest_review or {}).get("status", "UNKNOWN")).upper(),
+        backtest_review_brief=str((backtest_review or {}).get("brief", "")).strip(),
+        backtest_review_next_action=str((backtest_review or {}).get("required_next_action", "")).strip(),
+        website_status=website_status,
+        website_issues=website_issues,
+        support_triage_status=str((support_triage or {}).get("status", "UNKNOWN")).upper(),
+        support_triage_brief=str((support_triage or {}).get("brief", "")).strip(),
+        sources=[
+            _source(root_path, phase3_rel, phase3),
+            _source(root_path, phase2_rel, phase2),
+            _source(root_path, daily_rel, daily),
+            _source(root_path, approvals_rel, approvals),
+            _source(root_path, data_quality_rel, data_quality),
+            _source(root_path, backtest_review_rel, backtest_review),
+            _source(root_path, support_triage_rel, support_triage),
+        ],
+    )

--- a/scripts/persona_router.py
+++ b/scripts/persona_router.py
@@ -286,11 +286,17 @@ def answer_persona(
     message: str,
     root: Path | str = ROOT,
     conversation_config: dict[str, Any] | None = None,
+    full_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Answer free text as a persona using only allowed local truth sources."""
 
     packet = build_truth_packet(persona=persona, message=message, root=root)
-    verbalizers = run_verbalizers(packet, config=conversation_config, root=root)
+    verbalizers = run_verbalizers(
+        packet,
+        config=conversation_config,
+        root=root,
+        full_config=full_config,
+    )
     verbalized = verbalizers["primary"]
     return {
         "ok": True,

--- a/scripts/persona_router.py
+++ b/scripts/persona_router.py
@@ -1,0 +1,333 @@
+"""Open-ended persona chat over local organization truth."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from persona_verbalizer import run_verbalizers
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ISSUE_STATUSES = {"BLOCKED", "RED", "AMBER", "YELLOW"}
+ROLE_PATTERNS = (
+    "what do you do",
+    "who are you",
+    "what is your role",
+    "your role",
+    "how do you help",
+)
+
+
+@dataclass(frozen=True)
+class PersonaSpec:
+    slug: str
+    display_name: str
+    sources: tuple[str, ...]
+    unknown_answer: str
+
+
+PERSONAS: dict[str, PersonaSpec] = {
+    "chief-of-staff": PersonaSpec(
+        slug="chief-of-staff",
+        display_name="Chief of Staff",
+        sources=(
+            "state/board_approval_decisions.json",
+            "reports/phase3_holding_latest.json",
+            "reports/skills/risk-aggregate-daily/latest.json",
+            "reports/skills/portfolio-retro-weekly/latest.json",
+            "reports/skills/backtest-review/latest.json",
+            "reports/skills/support-triage/latest.json",
+        ),
+        unknown_answer="I do not have current company evidence to answer that yet.",
+    ),
+    "risk-officer": PersonaSpec(
+        slug="risk-officer",
+        display_name="Risk Officer",
+        sources=(
+            "reports/skills/backtest-review/latest.json",
+            "reports/skills/data-quality-daily/latest.json",
+            "reports/skills/pre-deploy-checklist/latest.json",
+            "state/board_approval_decisions.json",
+        ),
+        unknown_answer="I do not have current risk evidence to answer that yet.",
+    ),
+    "quant-ops": PersonaSpec(
+        slug="quant-ops",
+        display_name="Quant Ops",
+        sources=(
+            "reports/skills/data-quality-daily/latest.json",
+            "reports/skills/backtest-review/latest.json",
+            "reports/skills/broker-reconcile/latest.json",
+        ),
+        unknown_answer="I do not have current Quant Ops evidence to answer that yet.",
+    ),
+    "growth-lead": PersonaSpec(
+        slug="growth-lead",
+        display_name="Growth Lead",
+        sources=(
+            "reports/phase2_divisions_latest.json",
+            "reports/skills/analytics-weekly/latest.json",
+            "reports/skills/portfolio-retro-weekly/latest.json",
+        ),
+        unknown_answer="I do not have current growth evidence to answer that yet.",
+    ),
+    "editorial-lead": PersonaSpec(
+        slug="editorial-lead",
+        display_name="Editorial Lead",
+        sources=(
+            "reports/skills/content-brief-to-draft/latest.json",
+            "reports/skills/analytics-weekly/latest.json",
+            "state/content_studio.json",
+        ),
+        unknown_answer="I do not have current editorial queue evidence to answer that yet.",
+    ),
+    "engineering-ops": PersonaSpec(
+        slug="engineering-ops",
+        display_name="Engineering/Ops",
+        sources=(
+            "reports/daily_brief_latest.json",
+            "reports/phase2_divisions_latest.json",
+            "reports/phase3_holding_latest.json",
+            "reports/skills/portfolio-retro-weekly/latest.json",
+        ),
+        unknown_answer="I do not have current engineering or operations evidence to answer that yet.",
+    ),
+    "support-lead": PersonaSpec(
+        slug="support-lead",
+        display_name="Support Lead",
+        sources=(
+            "reports/skills/support-triage/latest.json",
+            "state/support_tickets.json",
+        ),
+        unknown_answer="I do not have current support evidence to answer that yet.",
+    ),
+    "finance-admin": PersonaSpec(
+        slug="finance-admin",
+        display_name="Finance/Admin",
+        sources=(
+            "reports/skills/monthly-close-prep/latest.json",
+            "reports/skills/infra-cost-review/latest.json",
+            "reports/skills/compliance-monitor/latest.json",
+        ),
+        unknown_answer="Finance/Admin is deferred until reliable finance sources exist.",
+    ),
+}
+
+ALIASES = {
+    "chief": "chief-of-staff",
+    "chief of staff": "chief-of-staff",
+    "cos": "chief-of-staff",
+    "risk": "risk-officer",
+    "risk officer": "risk-officer",
+    "quant": "quant-ops",
+    "quant ops": "quant-ops",
+    "growth": "growth-lead",
+    "growth lead": "growth-lead",
+    "editorial": "editorial-lead",
+    "editor": "editorial-lead",
+    "engineering": "engineering-ops",
+    "ops": "engineering-ops",
+    "support": "support-lead",
+    "support lead": "support-lead",
+    "finance": "finance-admin",
+    "finance admin": "finance-admin",
+}
+
+
+def normalize_persona(value: str) -> str:
+    cleaned = value.strip().lower().replace("_", "-")
+    cleaned = cleaned.replace(" ", "-") if cleaned in PERSONAS else cleaned
+    if cleaned in PERSONAS:
+        return cleaned
+    return ALIASES.get(value.strip().lower(), "chief-of-staff")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _load_sources(root: Path, spec: PersonaSpec) -> list[dict[str, Any]]:
+    loaded: list[dict[str, Any]] = []
+    for rel_path in spec.sources:
+        payload = _read_json(root / rel_path)
+        if payload:
+            loaded.append({"path": rel_path, "payload": payload})
+    return loaded
+
+
+def _status(payload: dict[str, Any]) -> str:
+    return str(payload.get("status") or payload.get("company_scorecard", {}).get("status") or "UNKNOWN").upper()
+
+
+def _brief(payload: dict[str, Any]) -> str:
+    if payload.get("brief"):
+        return str(payload.get("brief"))
+    scorecard = payload.get("company_scorecard", {})
+    if isinstance(scorecard, dict):
+        risks = scorecard.get("risks", [])
+        if isinstance(risks, list) and risks:
+            return str(risks[0])
+    return ""
+
+
+def _approval_count(source_rows: list[dict[str, Any]]) -> int:
+    for row in source_rows:
+        if row["path"] != "state/board_approval_decisions.json":
+            continue
+        snapshot = row["payload"].get("board_snapshot", {})
+        snapshot = snapshot if isinstance(snapshot, dict) else {}
+        approvals = snapshot.get("approvals", [])
+        return len(approvals) if isinstance(approvals, list) else 0
+    return 0
+
+
+def _issue_rows(source_rows: list[dict[str, Any]]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    for row in source_rows:
+        payload = row["payload"]
+        status = _status(payload)
+        brief = _brief(payload)
+        if status in ISSUE_STATUSES or brief:
+            issues.append(
+                {
+                    "source": str(row["path"]),
+                    "skill": str(payload.get("skill") or Path(str(row["path"])).parent.name),
+                    "status": status,
+                    "brief": brief,
+                    "owner_need": str(payload.get("owner_need") or "none"),
+                }
+            )
+    issues.sort(key=lambda item: (item["status"] != "BLOCKED", item["status"] != "RED", item["skill"]))
+    return issues
+
+
+def _owner_need(source_rows: list[dict[str, Any]], issues: list[dict[str, str]]) -> str:
+    if _approval_count(source_rows) > 0:
+        return "approve"
+    if any(item.get("owner_need") == "approve" for item in issues):
+        return "approve"
+    return "none"
+
+
+def classify_intent(message: str) -> str:
+    """Classify broad persona-chat intent without a model call."""
+
+    lowered = message.strip().lower()
+    if any(pattern in lowered for pattern in ROLE_PATTERNS):
+        return "role"
+    if any(word in lowered for word in ("why", "evidence", "source", "prove", "show me")):
+        return "evidence"
+    if any(word in lowered for word in ("approve", "approval", "decision")):
+        return "approval"
+    if any(word in lowered for word in ("do", "fix", "execute", "send", "publish", "deploy")):
+        return "action"
+    return "status"
+
+
+def build_truth_packet(persona: str, message: str, root: Path | str = ROOT) -> dict[str, Any]:
+    """Build the bounded truth packet that a future NanoClaw layer may verbalize."""
+
+    root_path = Path(root)
+    slug = normalize_persona(persona)
+    spec = PERSONAS[slug]
+    rows = _load_sources(root_path, spec)
+    issues = _issue_rows(rows)
+    sources = [row["path"] for row in rows]
+    truth_state = "known" if rows else "unknown"
+    owner_need = _owner_need(rows, issues)
+    packet = {
+        "schema_version": "persona_truth_packet.v1",
+        "persona": spec.slug,
+        "display_name": spec.display_name,
+        "intent": classify_intent(message),
+        "user_message": message,
+        "truth_state": truth_state,
+        "owner_need": owner_need,
+        "approvals_count": _approval_count(rows),
+        "evidence": issues,
+        "sources": sources,
+        "unknowns": [] if rows else [spec.unknown_answer],
+        "unknown_answer": spec.unknown_answer,
+        "policy": {
+            "allowed_claim_source": "truth_packet_only",
+            "no_tool_calls": True,
+            "no_file_reads": True,
+            "no_writes": True,
+        },
+    }
+    packet["packet_id"] = _packet_id(packet)
+    return packet
+
+
+def _packet_id(packet: dict[str, Any]) -> str:
+    stable = {
+        "schema_version": packet.get("schema_version"),
+        "persona": packet.get("persona"),
+        "intent": packet.get("intent"),
+        "user_message": packet.get("user_message"),
+        "evidence": packet.get("evidence", []),
+        "sources": packet.get("sources", []),
+    }
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def answer_persona(
+    persona: str,
+    message: str,
+    root: Path | str = ROOT,
+    conversation_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Answer free text as a persona using only allowed local truth sources."""
+
+    packet = build_truth_packet(persona=persona, message=message, root=root)
+    verbalizers = run_verbalizers(packet, config=conversation_config, root=root)
+    verbalized = verbalizers["primary"]
+    return {
+        "ok": True,
+        "persona": packet["persona"],
+        "display_name": packet["display_name"],
+        "message": message,
+        "answer": verbalized["answer"],
+        "intent": packet["intent"],
+        "truth_state": packet["truth_state"],
+        "owner_need": packet["owner_need"],
+        "sources": packet["sources"],
+        "evidence": packet["evidence"],
+        "truth_packet": packet,
+        "verbalizer": {
+            "provider": verbalized["provider"],
+            "unsupported_claims": verbalized["unsupported_claims"],
+            "evidence_mode": verbalized["evidence_mode"],
+            "confidence": verbalized["confidence"],
+        },
+        "shadow_verbalizer": verbalizers["shadow"],
+        "grounding_mode": "deterministic_local_truth",
+        "no_model_calls": verbalized["no_model_calls"],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ask a persona a free-text question over local org truth.")
+    parser.add_argument("--persona", required=True, help="Persona name or slug.")
+    parser.add_argument("--message", required=True, help="Free-text message.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(answer_persona(args.persona, args.message, root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/persona_verbalizer.py
+++ b/scripts/persona_verbalizer.py
@@ -287,6 +287,7 @@ def run_verbalizers(
     if mode == "live":
         live = nanoclaw_live_verbalize(packet, config=full_config or {})
         verdict = verify_verbalizer_output(live)
+        _append_live_log(packet=packet, verdict=verdict, config=cfg, root=Path(root))
         if verdict["accepted"]:
             primary = live
         else:
@@ -296,3 +297,24 @@ def run_verbalizers(
         primary = fallback
 
     return {"primary": primary, "shadow": shadow}
+
+
+def _append_live_log(
+    packet: dict[str, Any],
+    verdict: dict[str, Any],
+    config: dict[str, Any],
+    root: Path,
+) -> None:
+    nanoclaw_cfg = config.get("nanoclaw", {}) if isinstance(config.get("nanoclaw", {}), dict) else {}
+    log_path = str(nanoclaw_cfg.get("live_log_path") or "state/nanoclaw_live_log.jsonl")
+    path = root / log_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "persona": packet.get("persona"),
+        "intent": packet.get("intent"),
+        "packet_id": packet.get("packet_id"),
+        "accepted": bool(verdict.get("accepted")),
+        "reason": str(verdict.get("reason") or ""),
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")

--- a/scripts/persona_verbalizer.py
+++ b/scripts/persona_verbalizer.py
@@ -77,9 +77,13 @@ def _chief_status(packet: dict[str, Any]) -> str:
     evidence = packet.get("evidence", [])
     if evidence:
         lead = evidence[0]
-        parts.append(f"I would focus there first: {_clean_brief(str(lead.get('brief') or ''))}")
-    if len(evidence) > 1:
-        parts.append(f"There are {len(evidence)} current evidence items behind that.")
+        lead_brief = _clean_brief(str(lead.get("brief") or ""))
+        if str(lead.get("status") or "").upper() == "GREEN":
+            parts.append(lead_brief)
+        else:
+            parts.append(f"I would focus there first: {lead_brief}")
+            if len(evidence) > 1:
+                parts.append(f"There are {len(evidence)} current evidence items behind that.")
     if len(parts) == 1:
         return "I do not see a stored issue needing you right now."
     return " ".join(parts)

--- a/scripts/persona_verbalizer.py
+++ b/scripts/persona_verbalizer.py
@@ -259,15 +259,40 @@ def nanoclaw_shadow_verbalize(packet: dict[str, Any], config: dict[str, Any], ro
     }
 
 
+def _effective_nanoclaw_mode(persona: str, config: dict[str, Any]) -> str:
+    """Resolve mode: per-persona override beats global, default off."""
+    nanoclaw_cfg = config.get("nanoclaw", {}) if isinstance(config.get("nanoclaw", {}), dict) else {}
+    personas_cfg = nanoclaw_cfg.get("personas", {}) if isinstance(nanoclaw_cfg.get("personas", {}), dict) else {}
+    per = personas_cfg.get(persona)
+    if isinstance(per, str) and per:
+        return per.lower()
+    mode = nanoclaw_cfg.get("mode")
+    return str(mode).lower() if isinstance(mode, str) else "off"
+
+
 def run_verbalizers(
     packet: dict[str, Any],
     config: dict[str, Any] | None = None,
     root: Path | str = ".",
+    full_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Run the live deterministic verbalizer plus optional NanoClaw shadow."""
+    """Run the deterministic verbalizer, plus NanoClaw shadow or live based on config."""
 
     cfg = config if isinstance(config, dict) else {}
     _append_shadow_inbox(packet=packet, config=cfg, root=Path(root))
-    primary = deterministic_verbalize(packet)
+    fallback = deterministic_verbalize(packet)
     shadow = nanoclaw_shadow_verbalize(packet=packet, config=cfg, root=Path(root))
+
+    mode = _effective_nanoclaw_mode(str(packet.get("persona") or ""), cfg)
+    if mode == "live":
+        live = nanoclaw_live_verbalize(packet, config=full_config or {})
+        verdict = verify_verbalizer_output(live)
+        if verdict["accepted"]:
+            primary = live
+        else:
+            fallback["nanoclaw_live_rejected_reason"] = verdict["reason"]
+            primary = fallback
+    else:
+        primary = fallback
+
     return {"primary": primary, "shadow": shadow}

--- a/scripts/persona_verbalizer.py
+++ b/scripts/persona_verbalizer.py
@@ -126,6 +126,64 @@ def deterministic_verbalize(packet: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+NANOCLAW_LIVE_SYSTEM_PROMPT = (
+    "You are a company persona speaking to the owner. "
+    "You will receive a JSON truth packet. Reply ONLY using facts present in that JSON. "
+    "Never invent numbers, names, dates, statuses, or events. "
+    "Do not mention the JSON, the schema, or that you are an AI. "
+    "Speak as the persona named in display_name. Keep it to one short paragraph, plain prose, no markdown."
+)
+
+
+def nanoclaw_live_verbalize(
+    packet: dict[str, Any],
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call local Ollama to verbalize a sealed truth packet. R1: local only.
+
+    Returns a verbalizer-shaped dict on success, or an empty answer on any
+    failure (the caller falls back to deterministic_verbalize). No retries,
+    no streaming, single hard timeout.
+    """
+    import urllib.request  # stdlib only
+    import urllib.error
+
+    cfg = config if isinstance(config, dict) else {}
+    phase2 = cfg.get("phase2", {}) if isinstance(cfg.get("phase2", {}), dict) else {}
+    model = str(phase2.get("ollama_model") or "llama3.2:latest").replace("ollama/", "")
+    base_url = str(phase2.get("ollama_base_url") or "http://127.0.0.1:11434").rstrip("/")
+
+    prompt = (
+        f"{NANOCLAW_LIVE_SYSTEM_PROMPT}\n\n"
+        f"TRUTH PACKET:\n{json.dumps(packet, sort_keys=True)}\n\n"
+        f"OWNER MESSAGE: {packet.get('message') or ''}\n"
+        f"REPLY:"
+    )
+    payload = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/api/generate",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    answer = ""
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            answer = str(result.get("response") or "").strip()
+    except (urllib.error.URLError, json.JSONDecodeError, OSError, TimeoutError):
+        answer = ""
+    return {
+        "answer": answer,
+        "unsupported_claims": [],
+        "evidence_mode": "hidden" if packet.get("evidence") else "none",
+        "confidence": "low",
+        "provider": "nanoclaw_live",
+        "no_model_calls": False,
+        "model": model,
+    }
+
+
 def verify_verbalizer_output(output: dict[str, Any]) -> dict[str, Any]:
     """Validate a verbalizer response before it can be used or compared."""
 

--- a/scripts/persona_verbalizer.py
+++ b/scripts/persona_verbalizer.py
@@ -1,0 +1,211 @@
+"""Persona verbalization boundary.
+
+This module is the future NanoClaw integration point. Today it provides a
+deterministic fallback verbalizer so persona chat can move through a truth
+packet contract without making model calls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROLE_ANSWERS = {
+    "chief-of-staff": (
+        "I help you run the company day to day. I keep track of what needs your attention, "
+        "what is blocked, what can wait, and which evidence supports each recommendation."
+    ),
+    "risk-officer": (
+        "I protect the company from avoidable risk. I look for missing evidence, blocked "
+        "guardrails, and decisions that should not move forward without approval."
+    ),
+    "quant-ops": (
+        "I keep the trading operation honest. I watch data quality, backtest readiness, "
+        "broker reconciliation, and anything that could make research or live trading unsafe."
+    ),
+    "growth-lead": (
+        "I turn website evidence into growth priorities. I watch traffic, revenue, content "
+        "performance, and anomalies that need a decision."
+    ),
+    "editorial-lead": (
+        "I manage the content workflow. I help turn briefs into drafts, keep quality and SEO "
+        "visible, and escalate anything that needs human publishing judgment."
+    ),
+    "engineering-ops": (
+        "I keep the operating layer reliable. I watch incidents, deploy readiness, tests, and "
+        "the parts of the system that could quietly stop working."
+    ),
+    "support-lead": (
+        "I watch customer support once a real ticket source exists. I classify routine issues, "
+        "surface exceptions, and keep unresolved customer pain visible."
+    ),
+    "finance-admin": (
+        "I am deferred until reliable finance sources exist. Once wired, I will watch close, "
+        "cost, cash, compliance, and admin follow-through."
+    ),
+}
+
+
+def _clean_brief(brief: str) -> str:
+    cleaned = brief.strip()
+    for prefix in (
+        "Backtest review is BLOCKED. ",
+        "Portfolio retro is BLOCKED. ",
+        "Support triage is BLOCKED. ",
+        "The company is RED in the latest stored CEO report. ",
+    ):
+        if cleaned.startswith(prefix):
+            return cleaned.removeprefix(prefix)
+    return cleaned
+
+
+def _approval_phrase(count: int) -> str:
+    if count == 1:
+        return "You have one approval waiting."
+    if count > 1:
+        return f"You have {count} approvals waiting."
+    return ""
+
+
+def _chief_status(packet: dict[str, Any]) -> str:
+    parts: list[str] = ["Welcome back."]
+    approvals = _approval_phrase(int(packet.get("approvals_count") or 0))
+    if approvals:
+        parts.append(approvals)
+    evidence = packet.get("evidence", [])
+    if evidence:
+        lead = evidence[0]
+        parts.append(f"I would focus there first: {_clean_brief(str(lead.get('brief') or ''))}")
+    if len(evidence) > 1:
+        parts.append(f"There are {len(evidence)} current evidence items behind that.")
+    if len(parts) == 1:
+        return "I do not see a stored issue needing you right now."
+    return " ".join(parts)
+
+
+def _risk_status(packet: dict[str, Any]) -> str:
+    evidence = packet.get("evidence", [])
+    blocking = [item for item in evidence if item.get("status") in {"BLOCKED", "RED"}]
+    if blocking:
+        lead = blocking[0]
+        return f"I object for now. I would not move it forward until this is resolved. {lead.get('brief')}"
+    if evidence:
+        return f"I do not see a hard block, but I would review this first: {evidence[0].get('brief')}"
+    return "I do not see a stored risk objection in my current sources."
+
+
+def deterministic_verbalize(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return a natural answer from a bounded truth packet without model calls."""
+
+    persona = str(packet.get("persona") or "")
+    intent = str(packet.get("intent") or "status")
+    evidence = packet.get("evidence", [])
+    if intent == "role":
+        answer = ROLE_ANSWERS.get(persona, "I answer from the company records available to my role.")
+    elif persona == "chief-of-staff":
+        answer = _chief_status(packet)
+    elif persona == "risk-officer":
+        answer = _risk_status(packet)
+    elif evidence:
+        answer = f"{packet.get('display_name')} has current evidence: {evidence[0].get('brief')}"
+    else:
+        answer = str(packet.get("unknown_answer") or "I do not have current evidence to answer that yet.")
+    return {
+        "answer": answer,
+        "unsupported_claims": [],
+        "evidence_mode": "hidden" if evidence else "none",
+        "confidence": "high" if packet.get("truth_state") == "known" or intent == "role" else "low",
+        "provider": "deterministic_fallback",
+        "no_model_calls": True,
+    }
+
+
+def verify_verbalizer_output(output: dict[str, Any]) -> dict[str, Any]:
+    """Validate a verbalizer response before it can be used or compared."""
+
+    unsupported = output.get("unsupported_claims", [])
+    if isinstance(unsupported, list) and unsupported:
+        return {"accepted": False, "reason": "unsupported_claims"}
+    answer = str(output.get("answer") or "").strip()
+    if not answer:
+        return {"accepted": False, "reason": "empty_answer"}
+    return {"accepted": True, "reason": "ok"}
+
+
+def _read_jsonl_latest(path: Path, persona: str, intent: str) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        rows = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    for line in reversed(rows):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("persona") == persona and payload.get("intent") == intent:
+            return payload
+    return {}
+
+
+def _append_shadow_inbox(packet: dict[str, Any], config: dict[str, Any], root: Path) -> None:
+    nanoclaw_cfg = config.get("nanoclaw", {}) if isinstance(config.get("nanoclaw", {}), dict) else {}
+    if nanoclaw_cfg.get("mode") != "shadow":
+        return
+    inbox_path = str(nanoclaw_cfg.get("shadow_inbox_path") or "state/nanoclaw_shadow_inbox.jsonl")
+    path = root / inbox_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "type": "nanoclaw_shadow_request",
+        "packet_id": packet.get("packet_id"),
+        "packet": packet,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def nanoclaw_shadow_verbalize(packet: dict[str, Any], config: dict[str, Any], root: Path) -> dict[str, Any]:
+    """Read a future NanoClaw outbox record for shadow comparison only."""
+
+    nanoclaw_cfg = config.get("nanoclaw", {}) if isinstance(config.get("nanoclaw", {}), dict) else {}
+    if nanoclaw_cfg.get("mode") != "shadow":
+        return {"provider": "nanoclaw_shadow", "enabled": False, "accepted": False, "reason": "disabled"}
+    outbox_path = str(nanoclaw_cfg.get("shadow_outbox_path") or "").strip()
+    if not outbox_path:
+        return {"provider": "nanoclaw_shadow", "enabled": True, "accepted": False, "reason": "missing_outbox_path"}
+    output = _read_jsonl_latest(root / outbox_path, persona=str(packet["persona"]), intent=str(packet["intent"]))
+    if not output:
+        return {"provider": "nanoclaw_shadow", "enabled": True, "accepted": False, "reason": "no_shadow_output"}
+    if output.get("packet_id") != packet.get("packet_id"):
+        return {"provider": "nanoclaw_shadow", "enabled": True, "accepted": False, "reason": "packet_id_mismatch"}
+    verdict = verify_verbalizer_output(output)
+    return {
+        "provider": "nanoclaw_shadow",
+        "enabled": True,
+        "accepted": verdict["accepted"],
+        "reason": verdict["reason"],
+        "answer": str(output.get("answer") or ""),
+        "confidence": str(output.get("confidence") or "unknown"),
+        "unsupported_claims": output.get("unsupported_claims", []),
+    }
+
+
+def run_verbalizers(
+    packet: dict[str, Any],
+    config: dict[str, Any] | None = None,
+    root: Path | str = ".",
+) -> dict[str, Any]:
+    """Run the live deterministic verbalizer plus optional NanoClaw shadow."""
+
+    cfg = config if isinstance(config, dict) else {}
+    _append_shadow_inbox(packet=packet, config=cfg, root=Path(root))
+    primary = deterministic_verbalize(packet)
+    shadow = nanoclaw_shadow_verbalize(packet=packet, config=cfg, root=Path(root))
+    return {"primary": primary, "shadow": shadow}

--- a/scripts/skill_backtest_review.py
+++ b/scripts/skill_backtest_review.py
@@ -1,0 +1,297 @@
+"""Backtest review guardrail built from local MT5 research evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from org_truth_retriever import ROOT
+
+
+SKILL_NAME = "backtest-review"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _relative(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _latest_json(root: Path, folder: Path, pattern: str) -> Path | None:
+    target = root / folder
+    if not target.exists():
+        return None
+    candidates = [path for path in target.glob(pattern) if path.is_file()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return 0
+    return 0
+
+
+def _decision_counts(review_results: list[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in review_results:
+        if not isinstance(item, dict):
+            continue
+        decision = str(item.get("decision", "")).upper()
+        if not decision:
+            continue
+        counts[decision] = counts.get(decision, 0) + 1
+    return counts
+
+
+def _research_metrics(research: dict[str, Any]) -> dict[str, Any]:
+    summary = research.get("summary", {})
+    validation = research.get("validation", {})
+    review_results = research.get("review_results", [])
+    if not isinstance(summary, dict):
+        summary = {}
+    if not isinstance(validation, dict):
+        validation = {}
+    if not isinstance(review_results, list):
+        review_results = []
+
+    counts = _decision_counts(review_results)
+    selected = _as_int(summary.get("selected_for_review")) or len(review_results)
+    approved = _as_int(summary.get("approved")) or counts.get("APPROVE", 0)
+    rejected = _as_int(summary.get("rejected")) or counts.get("REJECT", 0)
+    approve_blocked = counts.get("APPROVE_BLOCKED", 0)
+    pass_rate = round((approved / selected) * 100, 1) if selected else 0.0
+    return {
+        "selected_for_review": selected,
+        "approved_count": approved,
+        "rejected_count": rejected,
+        "approve_blocked_count": approve_blocked,
+        "with_out_of_sample": _as_int(validation.get("with_out_of_sample")),
+        "with_walk_forward": _as_int(validation.get("with_walk_forward")),
+        "overfit_flagged": _as_int(validation.get("overfit_flagged")),
+        "pass_unchanged_rate_pct": pass_rate,
+    }
+
+
+def _data_quality_status(root: Path) -> tuple[str, str, str]:
+    path = root / "reports" / "skills" / "data-quality-daily" / "latest.json"
+    if not path.exists():
+        return "MISSING", "No data-quality guardrail artifact found.", ""
+    payload = _read_json(path)
+    status = str(payload.get("status", "UNKNOWN")).upper()
+    brief = str(payload.get("brief", "Data-quality artifact has no brief."))
+    return status, brief, _relative(root, path)
+
+
+def _status_and_reasons(metrics: dict[str, Any], data_quality_status: str) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if data_quality_status != "GREEN":
+        reasons.append(f"Data quality is {data_quality_status}.")
+    if metrics["approved_count"] <= 0:
+        reasons.append("No reviewed candidate is approved.")
+    if metrics["with_out_of_sample"] <= 0:
+        reasons.append("No out-of-sample validation is recorded.")
+    if metrics["with_walk_forward"] <= 0:
+        reasons.append("No walk-forward validation is recorded.")
+    if metrics["overfit_flagged"] > 0:
+        reasons.append(f"{metrics['overfit_flagged']} candidate(s) are flagged for overfit risk.")
+    if reasons:
+        return "BLOCKED", reasons
+    return "PASS_FOR_OWNER_APPROVAL", ["Evidence clears the local guardrail, but owner approval is still required."]
+
+
+def _brief(status: str, metrics: dict[str, Any], reasons: list[str]) -> str:
+    if status == "BLOCKED":
+        return (
+            "Backtest review is BLOCKED. "
+            f"Latest MT5 research selected {metrics['selected_for_review']} candidate(s), "
+            f"approved {metrics['approved_count']}, rejected {metrics['rejected_count']}, "
+            f"and has {metrics['with_out_of_sample']} out-of-sample / "
+            f"{metrics['with_walk_forward']} walk-forward evidence. {reasons[0]}"
+        )
+    return (
+        "Backtest review passed the local evidence gate for owner approval. "
+        f"{metrics['approved_count']} of {metrics['selected_for_review']} reviewed candidate(s) "
+        "passed with data-quality, out-of-sample, and walk-forward evidence."
+    )
+
+
+def _required_next_action(status: str) -> str:
+    if status == "BLOCKED":
+        return "Do not move any reviewed strategy to forward-test; fix the evidence gaps and rerun review."
+    return "Request owner approval; this Guardrail skill cannot approve live or forward trading."
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Backtest Review",
+        "",
+        f"Generated UTC: {payload['generated_at_utc']}",
+        f"Status: {payload['status']}",
+        f"Autonomy: {payload['autonomy']}",
+        f"Owner need: {payload['owner_need']}",
+        "",
+        "## Brief",
+        "",
+        payload["brief"],
+        "",
+        "## Required Next Action",
+        "",
+        payload["required_next_action"],
+        "",
+        "## Metrics",
+        "",
+    ]
+    for key, value in payload["metrics"].items():
+        lines.append(f"- {key}: {value}")
+    lines.extend(["", "## Evidence Gaps", ""])
+    for reason in payload["reasons"]:
+        lines.append(f"- {reason}")
+    lines.extend(["", "## Sources", ""])
+    for source in payload["sources"]:
+        lines.append(f"- `{source}`")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _blocked_without_research(root_path: Path) -> dict[str, Any]:
+    stamp = _utc_stamp()
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    payload: dict[str, Any] = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "autonomy": "Guardrail",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": "BLOCKED",
+        "owner_need": "none",
+        "brief": "Backtest review is BLOCKED. No MT5 research artifact found.",
+        "required_next_action": "Create or locate a local MT5 research artifact before review.",
+        "metrics": {
+            "selected_for_review": 0,
+            "approved_count": 0,
+            "rejected_count": 0,
+            "approve_blocked_count": 0,
+            "with_out_of_sample": 0,
+            "with_walk_forward": 0,
+            "overfit_flagged": 0,
+            "pass_unchanged_rate_pct": 0.0,
+        },
+        "reasons": ["No MT5 research artifact found."],
+        "sources": [],
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+    _write_outputs(root_path, payload, markdown_rel, json_rel)
+    return payload
+
+
+def _write_outputs(root_path: Path, payload: dict[str, Any], markdown_rel: Path, json_rel: Path) -> None:
+    latest_md_rel = Path("reports") / "skills" / SKILL_NAME / "latest.md"
+    latest_json_rel = Path("reports") / "skills" / SKILL_NAME / "latest.json"
+    _write_markdown(root_path / markdown_rel, payload)
+    _write_json(root_path / json_rel, payload)
+    _write_markdown(root_path / latest_md_rel, payload)
+    _write_json(root_path / latest_json_rel, payload)
+
+
+def run_backtest_review(root: Path | str = ROOT) -> dict[str, Any]:
+    """Write a conservative local backtest-review guardrail report."""
+
+    root_path = Path(root)
+    research_path = _latest_json(
+        root_path,
+        Path("mt5-agentic-desk") / "logs" / "research",
+        "research_*.json",
+    )
+    if research_path is None:
+        return _blocked_without_research(root_path)
+
+    research = _read_json(research_path)
+    metrics = _research_metrics(research)
+    dq_status, dq_brief, dq_source = _data_quality_status(root_path)
+    status, reasons = _status_and_reasons(metrics, dq_status)
+
+    stamp = _utc_stamp()
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    sources = [_relative(root_path, research_path)]
+    if dq_source:
+        sources.append(dq_source)
+
+    qualification_path = _latest_json(
+        root_path,
+        Path("mt5-agentic-desk") / "logs" / "strategy_qualification",
+        "strategy_qualification_*.json",
+    )
+    if qualification_path is not None:
+        sources.append(_relative(root_path, qualification_path))
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "autonomy": "Guardrail",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "owner_need": "approve" if status == "PASS_FOR_OWNER_APPROVAL" else "none",
+        "brief": _brief(status, metrics, reasons),
+        "required_next_action": _required_next_action(status),
+        "data_quality": {
+            "status": dq_status,
+            "brief": dq_brief,
+        },
+        "metrics": metrics,
+        "reasons": reasons,
+        "sources": sources,
+        "hard_rule": "Productize the process, not the trades.",
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+    _write_outputs(root_path, payload, markdown_rel, json_rel)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a backtest-review guardrail artifact.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(run_backtest_review(root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill_data_quality_daily.py
+++ b/scripts/skill_data_quality_daily.py
@@ -1,0 +1,203 @@
+"""Data quality daily guardrail built from local evidence files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from org_truth_retriever import ROOT
+
+
+SKILL_NAME = "data-quality-daily"
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+    source: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "source": self.source,
+        }
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _today_utc() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _parse_evidence_date(path: Path) -> date | None:
+    stem = path.stem
+    raw = stem.replace("daily_summary_", "")
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _latest_mt5_summary(root: Path) -> Path | None:
+    evidence_dir = root / "mt5-agentic-desk" / "logs" / "evidence"
+    if not evidence_dir.exists():
+        return None
+    candidates = [
+        path
+        for path in evidence_dir.glob("daily_summary_*.json")
+        if _parse_evidence_date(path) is not None
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: _parse_evidence_date(path) or date.min)
+
+
+def _mt5_evidence_check(root: Path, as_of: date) -> CheckResult:
+    latest = _latest_mt5_summary(root)
+    if latest is None:
+        return CheckResult(
+            name="MT5 evidence freshness",
+            status="BLOCKED",
+            detail="No MT5 daily evidence summary found.",
+        )
+    evidence_date = _parse_evidence_date(latest)
+    if evidence_date is None:
+        return CheckResult(
+            name="MT5 evidence freshness",
+            status="BLOCKED",
+            detail="Latest MT5 evidence summary has an invalid date.",
+            source=str(latest.relative_to(root)).replace("\\", "/"),
+        )
+    age_days = (as_of - evidence_date).days
+    status = "GREEN" if age_days <= 1 else "RED"
+    detail = f"Latest MT5 daily evidence summary is {age_days} day(s) old."
+    return CheckResult(
+        name="MT5 evidence freshness",
+        status=status,
+        detail=detail,
+        source=str(latest.relative_to(root)).replace("\\", "/"),
+    )
+
+
+def _static_na_checks() -> list[CheckResult]:
+    return [
+        CheckResult(
+            name="Corporate actions",
+            status="N/A",
+            detail="Not applicable to current FX/Polymarket evidence scope.",
+        ),
+        CheckResult(
+            name="Vendor cross-check",
+            status="N/A",
+            detail="No second market-data vendor is wired yet.",
+        ),
+        CheckResult(
+            name="Broker/clearing reconciliation",
+            status="N/A",
+            detail="No canonical broker, clearing, or internal blotter source exists yet.",
+        ),
+    ]
+
+
+def _overall_status(checks: list[CheckResult]) -> str:
+    statuses = {check.status for check in checks}
+    if "BLOCKED" in statuses:
+        return "BLOCKED"
+    if "RED" in statuses:
+        return "RED"
+    if "AMBER" in statuses:
+        return "AMBER"
+    return "GREEN"
+
+
+def _brief(status: str, checks: list[CheckResult]) -> str:
+    blocking = [check for check in checks if check.status in {"BLOCKED", "RED"}]
+    if blocking:
+        first = blocking[0]
+        return f"Trading data quality is {status}. {first.detail}"
+    return "Trading data quality is GREEN for the local checks that currently exist. Missing vendor and broker checks are explicitly marked N/A."
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Data Quality Daily",
+        "",
+        f"Generated UTC: {payload['generated_at_utc']}",
+        f"Status: {payload['status']}",
+        f"Owner need: {payload['owner_need']}",
+        "",
+        "## Brief",
+        "",
+        payload["brief"],
+        "",
+        "## Checks",
+        "",
+    ]
+    for check in payload["checks"]:
+        source = f" Source: `{check['source']}`." if check.get("source") else ""
+        lines.append(f"- {check['name']}: {check['status']} - {check['detail']}{source}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_data_quality_daily(root: Path | str = ROOT, as_of: date | None = None) -> dict[str, Any]:
+    """Write a conservative local data-quality guardrail report."""
+
+    root_path = Path(root)
+    current_date = as_of or _today_utc()
+    checks = [_mt5_evidence_check(root_path, current_date), *_static_na_checks()]
+    status = _overall_status(checks)
+    stamp = _utc_stamp()
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    latest_md_rel = Path("reports") / "skills" / SKILL_NAME / "latest.md"
+    latest_json_rel = Path("reports") / "skills" / SKILL_NAME / "latest.json"
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "owner_need": "none",
+        "brief": _brief(status, checks),
+        "checks": [check.to_dict() for check in checks],
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+    _write_markdown(root_path / markdown_rel, payload)
+    _write_json(root_path / json_rel, payload)
+    _write_markdown(root_path / latest_md_rel, payload)
+    _write_json(root_path / latest_json_rel, payload)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate data quality daily guardrail artifacts.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    parser.add_argument("--as-of", default="", help="Optional YYYY-MM-DD date for deterministic checks.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    as_of = date.fromisoformat(args.as_of) if args.as_of else None
+    print(json.dumps(run_data_quality_daily(root=Path(args.root), as_of=as_of), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill_portfolio_retro_weekly.py
+++ b/scripts/skill_portfolio_retro_weekly.py
@@ -1,0 +1,219 @@
+"""Portfolio retro weekly skill wrapper built from stored local artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from org_truth_retriever import ROOT
+
+
+SKILL_NAME = "portfolio-retro-weekly"
+ISSUE_STATUSES = {"AMBER", "BLOCKED", "RED", "YELLOW"}
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _rel(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root)).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _latest_skill_outputs(root: Path) -> list[dict[str, Any]]:
+    skills_dir = root / "reports" / "skills"
+    if not skills_dir.exists():
+        return []
+    outputs: list[dict[str, Any]] = []
+    for path in sorted(skills_dir.glob("*/latest.json")):
+        if path.parent.name == SKILL_NAME:
+            continue
+        payload = _read_json(path)
+        if not payload:
+            continue
+        skill = str(payload.get("skill") or path.parent.name).strip()
+        status = str(payload.get("status") or "UNKNOWN").upper()
+        outputs.append(
+            {
+                "skill": skill,
+                "status": status,
+                "owner_need": str(payload.get("owner_need") or "none").strip(),
+                "brief": str(payload.get("brief") or "").strip(),
+                "source": _rel(root, path),
+            }
+        )
+    return outputs
+
+
+def _approval_metrics(root: Path) -> tuple[int, int, str]:
+    path = root / "state" / "board_approval_decisions.json"
+    payload = _read_json(path)
+    if not payload:
+        return 0, 0, ""
+    snapshot = payload.get("board_snapshot", {})
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    approvals = snapshot.get("approvals", [])
+    decisions = payload.get("decisions", {})
+    pending_count = len(approvals) if isinstance(approvals, list) else 0
+    decisions_count = len(decisions) if isinstance(decisions, dict) else 0
+    return pending_count, decisions_count, _rel(root, path)
+
+
+def _open_issues(skill_outputs: list[dict[str, Any]]) -> list[dict[str, str]]:
+    issues = [item for item in skill_outputs if item["status"] in ISSUE_STATUSES]
+    issues.sort(key=lambda item: (item["status"] != "BLOCKED", item["skill"]))
+    return [
+        {
+            "skill": str(item["skill"]),
+            "status": str(item["status"]),
+            "brief": str(item["brief"]),
+            "source": str(item["source"]),
+        }
+        for item in issues
+    ]
+
+
+def _overall_status(skill_outputs: list[dict[str, Any]]) -> str:
+    if not skill_outputs:
+        return "BLOCKED"
+    statuses = {str(item["status"]).upper() for item in skill_outputs}
+    if "BLOCKED" in statuses:
+        return "BLOCKED"
+    if "RED" in statuses:
+        return "RED"
+    if statuses.intersection({"AMBER", "YELLOW"}):
+        return "AMBER"
+    return "GREEN"
+
+
+def _owner_need(skill_outputs: list[dict[str, Any]], pending_approvals_count: int) -> str:
+    if pending_approvals_count > 0:
+        return "approve"
+    if any(str(item.get("owner_need", "")).lower() == "approve" for item in skill_outputs):
+        return "approve"
+    return "none"
+
+
+def _brief(status: str, skill_outputs: list[dict[str, Any]], open_issues: list[dict[str, str]]) -> str:
+    if not skill_outputs:
+        return "Portfolio retro is BLOCKED. No skill outputs found under reports/skills/."
+    if open_issues:
+        first = open_issues[0]
+        return (
+            f"Portfolio retro is {status}. {len(open_issues)} unresolved issue(s) remain, "
+            f"led by {first['skill']}: {first['brief']}"
+        )
+    return f"Portfolio retro is GREEN. {len(skill_outputs)} skill output(s) are current and no unresolved issues were found."
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Portfolio Retro Weekly",
+        "",
+        f"Generated UTC: {payload['generated_at_utc']}",
+        f"Status: {payload['status']}",
+        f"Owner need: {payload['owner_need']}",
+        "",
+        "## Brief",
+        "",
+        payload["brief"],
+        "",
+        "## Skill Outputs",
+        "",
+    ]
+    for item in payload["skill_outputs"]:
+        lines.append(f"- {item['skill']}: {item['status']} - {item['brief']}")
+    if not payload["skill_outputs"]:
+        lines.append("- No skill outputs found.")
+    lines.extend(["", "## Open Issues", ""])
+    for item in payload["open_issues"]:
+        lines.append(f"- {item['skill']}: {item['status']} - {item['brief']}")
+    if not payload["open_issues"]:
+        lines.append("- No open issues found.")
+    lines.extend(["", "## Metrics", ""])
+    for key, value in payload["metrics"].items():
+        lines.append(f"- {key}: {value}")
+    lines.extend(["", "## Sources", ""])
+    for source in payload["sources"]:
+        lines.append(f"- `{source}`")
+    if not payload["sources"]:
+        lines.append("- No current sources found.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_portfolio_retro_weekly(root: Path | str = ROOT) -> dict[str, Any]:
+    """Write a weekly retro artifact from current local skill outputs."""
+
+    root_path = Path(root)
+    skill_outputs = _latest_skill_outputs(root_path)
+    pending_approvals_count, decisions_logged_count, approvals_source = _approval_metrics(root_path)
+    issues = _open_issues(skill_outputs)
+    status = _overall_status(skill_outputs)
+    stamp = _utc_stamp()
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    latest_md_rel = Path("reports") / "skills" / SKILL_NAME / "latest.md"
+    latest_json_rel = Path("reports") / "skills" / SKILL_NAME / "latest.json"
+    sources = [item["source"] for item in skill_outputs]
+    if approvals_source:
+        sources.append(approvals_source)
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "owner_need": _owner_need(skill_outputs, pending_approvals_count),
+        "brief": _brief(status, skill_outputs, issues),
+        "skill_outputs": skill_outputs,
+        "open_issues": issues,
+        "metrics": {
+            "skill_outputs_count": len(skill_outputs),
+            "unresolved_issues_count": len(issues),
+            "pending_approvals_count": pending_approvals_count,
+            "decisions_logged_count": decisions_logged_count,
+        },
+        "sources": sources,
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+    _write_markdown(root_path / markdown_rel, payload)
+    _write_json(root_path / json_rel, payload)
+    _write_markdown(root_path / latest_md_rel, payload)
+    _write_json(root_path / latest_json_rel, payload)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate portfolio retro weekly skill artifacts.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(run_portfolio_retro_weekly(root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill_risk_aggregate_daily.py
+++ b/scripts/skill_risk_aggregate_daily.py
@@ -1,0 +1,100 @@
+"""Risk aggregate daily skill wrapper built on stored company truth."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from chief_of_staff import answer_company_question
+from org_truth_retriever import ROOT, collect_truth_bundle
+
+
+SKILL_NAME = "risk-aggregate-daily"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Risk Aggregate Daily",
+        "",
+        f"Generated UTC: {payload['generated_at_utc']}",
+        f"Status: {payload['status']}",
+        f"Owner need: {payload['owner_need']}",
+        "",
+        "## Brief",
+        "",
+        payload["brief"],
+        "",
+        "## Sources",
+        "",
+    ]
+    sources = payload.get("sources", [])
+    if sources:
+        lines.extend(f"- `{source}`" for source in sources)
+    else:
+        lines.append("- No current sources found.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_risk_aggregate_daily(root: Path | str = ROOT) -> dict[str, Any]:
+    """Create a natural daily risk brief plus structured sidecar."""
+
+    root_path = Path(root)
+    bundle = collect_truth_bundle(root_path)
+    answer = answer_company_question("What needs me today?", root=root_path)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    stamp = _utc_stamp()
+    report_dir = root_path / "reports" / "skills" / SKILL_NAME
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    latest_md_rel = Path("reports") / "skills" / SKILL_NAME / "latest.md"
+    latest_json_rel = Path("reports") / "skills" / SKILL_NAME / "latest.json"
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "generated_at_utc": generated_at,
+        "status": bundle.company_status,
+        "owner_need": answer["owner_need"],
+        "truth_state": answer["truth_state"],
+        "brief": answer["answer"],
+        "sources": answer["sources"],
+        "pending_approvals_count": len(bundle.pending_approvals),
+        "approved_awaiting_execution_count": len(bundle.approved_awaiting_execution),
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+
+    _write_markdown(root_path / markdown_rel, payload)
+    _write_json(root_path / json_rel, payload)
+    _write_markdown(root_path / latest_md_rel, payload)
+    _write_json(root_path / latest_json_rel, payload)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate risk aggregate daily skill artifacts.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(run_risk_aggregate_daily(root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill_support_triage.py
+++ b/scripts/skill_support_triage.py
@@ -1,0 +1,218 @@
+"""Support triage shadow-mode runtime for local ticket intake."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from org_truth_retriever import ROOT
+
+
+SKILL_NAME = "support-triage"
+DEFAULT_SOURCE = Path("state") / "support_tickets.json"
+ESCALATION_CATEGORIES = {"billing", "account", "legal"}
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _ticket_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = payload.get("tickets", [])
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _clean_text(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _classify(subject: str, body: str) -> str:
+    text = f"{subject} {body}".lower()
+    if any(term in text for term in ("refund", "charge", "charged", "billing", "invoice", "payment")):
+        return "billing"
+    if any(term in text for term in ("login", "password", "account", "sign in", "signin")):
+        return "account"
+    if any(term in text for term in ("legal", "terms", "privacy", "compliance")):
+        return "legal"
+    if any(term in text for term in ("bug", "broken", "error", "wrong", "not working", "fail")):
+        return "bug"
+    if any(term in text for term in ("feature", "request", "add", "could you", "can you")):
+        return "feature_request"
+    return "general"
+
+
+def _draft_reply(category: str) -> str:
+    if category == "bug":
+        return (
+            "Thanks for flagging this. We are going to reproduce the issue, check the affected tool, "
+            "and follow up once we have a fix or a clear workaround."
+        )
+    if category == "feature_request":
+        return (
+            "Thanks for the suggestion. We will review it against the current roadmap and look for "
+            "evidence that other users need the same workflow."
+        )
+    if category == "general":
+        return "Thanks for reaching out. We will review this and get back to you with the next useful step."
+    return ""
+
+
+def _triage_ticket(ticket: dict[str, Any]) -> dict[str, str]:
+    subject = _clean_text(ticket.get("subject"))
+    body = _clean_text(ticket.get("body"))
+    ticket_id = _clean_text(ticket.get("id")) or "untracked"
+    category = _classify(subject, body)
+    escalation_reason = ""
+    if category in ESCALATION_CATEGORIES:
+        escalation_reason = "Billing, refund, legal, or account issue."
+    return {
+        "ticket_id": ticket_id,
+        "subject": subject,
+        "category": category,
+        "draft_reply": _draft_reply(category),
+        "escalation_reason": escalation_reason,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# Support Triage",
+        "",
+        f"Generated UTC: {payload['generated_at_utc']}",
+        f"Status: {payload['status']}",
+        f"Autonomy: {payload['autonomy']}",
+        f"Owner need: {payload['owner_need']}",
+        "",
+        "## Brief",
+        "",
+        payload["brief"],
+        "",
+        "## Tickets",
+        "",
+    ]
+    if not payload["tickets"]:
+        lines.append("- No tickets triaged.")
+    for ticket in payload["tickets"]:
+        lines.append(f"- {ticket['ticket_id']}: {ticket['category']} - {ticket['subject']}")
+        if ticket["escalation_reason"]:
+            lines.append(f"  Escalation: {ticket['escalation_reason']}")
+        elif ticket["draft_reply"]:
+            lines.append(f"  Draft: {ticket['draft_reply']}")
+    lines.extend(["", "## Sources", ""])
+    for source in payload["sources"]:
+        lines.append(f"- `{source}`")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_outputs(root_path: Path, payload: dict[str, Any], markdown_rel: Path, json_rel: Path) -> None:
+    latest_md_rel = Path("reports") / "skills" / SKILL_NAME / "latest.md"
+    latest_json_rel = Path("reports") / "skills" / SKILL_NAME / "latest.json"
+    _write_markdown(root_path / markdown_rel, payload)
+    _write_json(root_path / json_rel, payload)
+    _write_markdown(root_path / latest_md_rel, payload)
+    _write_json(root_path / latest_json_rel, payload)
+
+
+def _base_payload(stamp: str) -> dict[str, Any]:
+    markdown_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.md"
+    json_rel = Path("reports") / "skills" / SKILL_NAME / f"{stamp}.json"
+    return {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "autonomy": "Approve",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "markdown_path": str(markdown_rel).replace("\\", "/"),
+        "json_path": str(json_rel).replace("\\", "/"),
+    }
+
+
+def run_support_triage(root: Path | str = ROOT) -> dict[str, Any]:
+    """Write a local support-triage artifact from state/support_tickets.json."""
+
+    root_path = Path(root)
+    source_rel = DEFAULT_SOURCE
+    source_path = root_path / source_rel
+    stamp = _utc_stamp()
+    payload = _base_payload(stamp)
+    markdown_rel = Path(payload["markdown_path"])
+    json_rel = Path(payload["json_path"])
+
+    if not source_path.exists():
+        payload.update(
+            {
+                "status": "BLOCKED",
+                "owner_need": "none",
+                "brief": "Support triage is BLOCKED. No local support ticket source found at state/support_tickets.json.",
+                "metrics": {"ticket_count": 0, "draft_count": 0, "escalation_count": 0},
+                "tickets": [],
+                "sources": [],
+            }
+        )
+        _write_outputs(root_path, payload, markdown_rel, json_rel)
+        return payload
+
+    triaged = [_triage_ticket(ticket) for ticket in _ticket_rows(_read_json(source_path))]
+    draft_count = sum(1 for ticket in triaged if ticket["draft_reply"])
+    escalation_count = sum(1 for ticket in triaged if ticket["escalation_reason"])
+    if triaged:
+        status = "AMBER"
+        owner_need = "approve" if draft_count else "none"
+        brief = (
+            f"Support triage found {len(triaged)} ticket(s): {draft_count} draft(s) "
+            f"and {escalation_count} escalation(s). Drafts require owner or CS lead approval."
+        )
+    else:
+        status = "GREEN"
+        owner_need = "none"
+        brief = "Support triage is GREEN. The local ticket source exists and has no open tickets."
+
+    payload.update(
+        {
+            "status": status,
+            "owner_need": owner_need,
+            "brief": brief,
+            "metrics": {
+                "ticket_count": len(triaged),
+                "draft_count": draft_count,
+                "escalation_count": escalation_count,
+            },
+            "tickets": triaged,
+            "sources": [str(source_rel).replace("\\", "/")],
+        }
+    )
+    _write_outputs(root_path, payload, markdown_rel, json_rel)
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a support-triage shadow-mode artifact.")
+    parser.add_argument("--root", default=str(ROOT), help="Project root.")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    print(json.dumps(run_support_triage(root=Path(args.root)), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -134,6 +134,7 @@ def build_parser() -> argparse.ArgumentParser:
     work.add_argument("--db", default=None, help="Optional work ledger DB path.")
     work_sub = work.add_subparsers(dest="work_action", required=True)
     work_sub.add_parser("status", help="Show work ledger status.")
+    work_sub.add_parser("reminders", help="Show owner action reminders.")
     work_show = work_sub.add_parser("show", help="Show one work item.")
     work_show.add_argument("--work-id", required=True, help="Work item id.")
     work_scan = work_sub.add_parser("scan_reviews", help="Scan review markdown into the work ledger.")
@@ -353,7 +354,12 @@ def main() -> None:
 
     if args.command == "work":
         from kernel.db import connect  # pylint: disable=import-outside-toplevel
-        from kernel.views import render_status_text, work_status  # pylint: disable=import-outside-toplevel
+        from kernel.views import (  # pylint: disable=import-outside-toplevel
+            render_reminder_text,
+            render_status_text,
+            work_reminders,
+            work_status,
+        )
         from kernel.work_items import (  # pylint: disable=import-outside-toplevel
             approve_work_item,
             block_work_item,
@@ -370,6 +376,11 @@ def main() -> None:
                     status = work_status(conn)
                     status["text"] = render_status_text(status)
                     _emit(status)
+                    return
+                if args.work_action == "reminders":
+                    reminders = work_reminders(conn)
+                    reminders["text"] = render_reminder_text(reminders)
+                    _emit(reminders)
                     return
                 if args.work_action == "show":
                     item = get_work_item(conn, args.work_id)

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -1,15 +1,18 @@
-"""Command router used by OpenClaw heartbeat and chat directives."""
+"""Command router used by the Telegram bridge and chat directives."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from monitoring import check_website, daily_brief, load_config, read_bot_logs, run_trading_script
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 def _emit(payload: dict) -> None:
@@ -126,6 +129,17 @@ def build_parser() -> argparse.ArgumentParser:
     loop_done = loop_sub.add_parser("done", help="Close a company loop.")
     loop_done.add_argument("--loop-id", required=True, help="Loop id.")
     loop_done.add_argument("--result", default="", help="Final result.")
+
+    work = sub.add_parser("work", help="Show the minimal work ledger.")
+    work.add_argument("--db", default=None, help="Optional work ledger DB path.")
+    work_sub = work.add_subparsers(dest="work_action", required=True)
+    work_sub.add_parser("status", help="Show work ledger status.")
+    work_scan = work_sub.add_parser("scan_reviews", help="Scan review markdown into the work ledger.")
+    work_scan.add_argument(
+        "--root",
+        default=str(ROOT / "finance_web_page"),
+        help="Root directory to scan for READY FOR MA REVIEW markdown.",
+    )
 
     mem_add = sub.add_parser("log_direction", help="Persist owner directive into vector memory.")
     mem_add.add_argument("--text", required=True, help="Directive text to persist.")
@@ -318,6 +332,28 @@ def main() -> None:
         if args.loop_action == "done":
             _emit(done_loop(config=config, loop_id=args.loop_id, result=args.result))
             return
+
+    if args.command == "work":
+        from kernel.db import connect  # pylint: disable=import-outside-toplevel
+        from kernel.views import render_status_text, work_status  # pylint: disable=import-outside-toplevel
+        from kernel.work_items import scan_ready_for_review_markdown  # pylint: disable=import-outside-toplevel
+
+        conn = connect(args.db)
+        try:
+            if args.work_action == "status":
+                status = work_status(conn)
+                status["text"] = render_status_text(status)
+                _emit(status)
+                return
+            if args.work_action == "scan_reviews":
+                result = scan_ready_for_review_markdown(conn, root=args.root)
+                status = work_status(conn)
+                result["status"] = status
+                result["text"] = render_status_text(status)
+                _emit(result)
+                return
+        finally:
+            conn.close()
 
     if args.command == "log_direction":
         _emit(_memory_add(config=config, text=args.text, source=args.source))

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -134,12 +134,30 @@ def build_parser() -> argparse.ArgumentParser:
     work.add_argument("--db", default=None, help="Optional work ledger DB path.")
     work_sub = work.add_subparsers(dest="work_action", required=True)
     work_sub.add_parser("status", help="Show work ledger status.")
+    work_show = work_sub.add_parser("show", help="Show one work item.")
+    work_show.add_argument("--work-id", required=True, help="Work item id.")
     work_scan = work_sub.add_parser("scan_reviews", help="Scan review markdown into the work ledger.")
     work_scan.add_argument(
         "--root",
         default=str(ROOT / "finance_web_page"),
         help="Root directory to scan for READY FOR MA REVIEW markdown.",
     )
+    work_approve = work_sub.add_parser("approve", help="Approve work with execution fields.")
+    work_approve.add_argument("--work-id", required=True, help="Work item id.")
+    work_approve.add_argument("--owner", required=True, help="Owner accountable for execution.")
+    work_approve.add_argument("--due-at", required=True, help="Expected completion time.")
+    work_approve.add_argument("--completion-signal", required=True, help="Evidence needed to close the work.")
+    work_approve.add_argument("--next-step", default="", help="Optional next execution step.")
+    work_start = work_sub.add_parser("start", help="Mark approved work in progress.")
+    work_start.add_argument("--work-id", required=True, help="Work item id.")
+    work_start.add_argument("--note", default="", help="Optional start note.")
+    work_block = work_sub.add_parser("block", help="Mark work blocked.")
+    work_block.add_argument("--work-id", required=True, help="Work item id.")
+    work_block.add_argument("--reason", required=True, help="Reason the work is blocked.")
+    work_done = work_sub.add_parser("done", help="Close work with result and evidence.")
+    work_done.add_argument("--work-id", required=True, help="Work item id.")
+    work_done.add_argument("--result", required=True, help="Final result.")
+    work_done.add_argument("--evidence", required=True, help="Evidence proving the result.")
 
     mem_add = sub.add_parser("log_direction", help="Persist owner directive into vector memory.")
     mem_add.add_argument("--text", required=True, help="Directive text to persist.")
@@ -336,21 +354,63 @@ def main() -> None:
     if args.command == "work":
         from kernel.db import connect  # pylint: disable=import-outside-toplevel
         from kernel.views import render_status_text, work_status  # pylint: disable=import-outside-toplevel
-        from kernel.work_items import scan_ready_for_review_markdown  # pylint: disable=import-outside-toplevel
+        from kernel.work_items import (  # pylint: disable=import-outside-toplevel
+            approve_work_item,
+            block_work_item,
+            done_work_item,
+            get_work_item,
+            scan_ready_for_review_markdown,
+            start_work_item,
+        )
 
         conn = connect(args.db)
         try:
-            if args.work_action == "status":
+            try:
+                if args.work_action == "status":
+                    status = work_status(conn)
+                    status["text"] = render_status_text(status)
+                    _emit(status)
+                    return
+                if args.work_action == "show":
+                    item = get_work_item(conn, args.work_id)
+                    _emit({"ok": item is not None, "item": item, "error": None if item else "work item not found"})
+                    return
+                if args.work_action == "scan_reviews":
+                    result = scan_ready_for_review_markdown(conn, root=args.root)
+                    status = work_status(conn)
+                    result["status"] = status
+                    result["text"] = render_status_text(status)
+                    _emit(result)
+                    return
+                if args.work_action == "approve":
+                    item = approve_work_item(
+                        conn,
+                        args.work_id,
+                        owner=args.owner,
+                        due_at=args.due_at,
+                        completion_signal=args.completion_signal,
+                        next_step=args.next_step.strip() or None,
+                    )
+                    _emit({"ok": True, "item": item})
+                    return
+                if args.work_action == "start":
+                    _emit({"ok": True, "item": start_work_item(conn, args.work_id, note=args.note)})
+                    return
+                if args.work_action == "block":
+                    _emit({"ok": True, "item": block_work_item(conn, args.work_id, args.reason)})
+                    return
+                if args.work_action == "done":
+                    item = done_work_item(
+                        conn,
+                        args.work_id,
+                        result=args.result,
+                        evidence=args.evidence,
+                    )
+                    _emit({"ok": True, "item": item})
+                    return
+            except ValueError as exc:
                 status = work_status(conn)
-                status["text"] = render_status_text(status)
-                _emit(status)
-                return
-            if args.work_action == "scan_reviews":
-                result = scan_ready_for_review_markdown(conn, root=args.root)
-                status = work_status(conn)
-                result["status"] = status
-                result["text"] = render_status_text(status)
-                _emit(result)
+                _emit({"ok": False, "error": str(exc), "status": status, "text": render_status_text(status)})
                 return
         finally:
             conn.close()

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -179,6 +179,9 @@ def build_parser() -> argparse.ArgumentParser:
     persona_chat.add_argument("--message", required=True, help="Natural owner message.")
     persona_chat.add_argument("--root", default=str(ROOT), help="Project root for truth retrieval.")
 
+    nanoclaw_status = sub.add_parser("nanoclaw_status", help="Show NanoClaw live acceptance rate per persona.")
+    nanoclaw_status.add_argument("--root", default=str(ROOT), help="Project root.")
+
     nanoclaw_shadow = sub.add_parser("nanoclaw_shadow_write", help="Write a local NanoClaw shadow response.")
     nanoclaw_shadow.add_argument("--root", default=str(ROOT), help="Project root for shadow inbox/outbox.")
     nanoclaw_shadow.add_argument(
@@ -499,6 +502,22 @@ def main() -> None:
                 root=Path(args.root),
                 conversation_config=config.get("conversation", {}),
                 full_config=config,
+            )
+        )
+        return
+
+    if args.command == "nanoclaw_status":
+        from nanoclaw_status import compute_status  # pylint: disable=import-outside-toplevel
+
+        nanoclaw_cfg = (config.get("conversation", {}) or {}).get("nanoclaw", {}) or {}
+        log_path = Path(args.root) / str(nanoclaw_cfg.get("live_log_path") or "state/nanoclaw_live_log.jsonl")
+        promotion = nanoclaw_cfg.get("promotion", {}) or {}
+        _emit(
+            compute_status(
+                log_path=log_path,
+                window=int(promotion.get("window") or 50),
+                min_accept_rate=float(promotion.get("min_accept_rate") or 0.80),
+                personas=nanoclaw_cfg.get("personas", {}) or {},
             )
         )
         return

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -498,6 +498,7 @@ def main() -> None:
                 message=args.message,
                 root=Path(args.root),
                 conversation_config=config.get("conversation", {}),
+                full_config=config,
             )
         )
         return

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -169,6 +169,45 @@ def build_parser() -> argparse.ArgumentParser:
     mem_search.add_argument("--query", required=True, help="Memory query text.")
     mem_search.add_argument("--top-k", type=int, default=5, help="Number of matches.")
 
+    ask_company = sub.add_parser("ask_company", help="Ask the truth-grounded Chief of Staff.")
+    ask_company.add_argument("--question", required=True, help="Natural owner question.")
+    ask_company.add_argument("--root", default=str(ROOT), help="Project root for truth retrieval.")
+    ask_company.add_argument("--json", action="store_true", help="Print structured JSON instead of conversational text.")
+
+    persona_chat = sub.add_parser("persona_chat", help="Ask a persona free text over local organization truth.")
+    persona_chat.add_argument("--persona", required=True, help="Persona name or slug.")
+    persona_chat.add_argument("--message", required=True, help="Natural owner message.")
+    persona_chat.add_argument("--root", default=str(ROOT), help="Project root for truth retrieval.")
+
+    nanoclaw_shadow = sub.add_parser("nanoclaw_shadow_write", help="Write a local NanoClaw shadow response.")
+    nanoclaw_shadow.add_argument("--root", default=str(ROOT), help="Project root for shadow inbox/outbox.")
+    nanoclaw_shadow.add_argument(
+        "--inbox-path",
+        default="state/nanoclaw_shadow_inbox.jsonl",
+        help="Relative shadow inbox path.",
+    )
+    nanoclaw_shadow.add_argument(
+        "--outbox-path",
+        default="state/nanoclaw_shadow_outbox.jsonl",
+        help="Relative shadow outbox path.",
+    )
+
+    risk_daily = sub.add_parser("risk_aggregate_daily", help="Generate the risk aggregate daily skill brief.")
+    risk_daily.add_argument("--root", default=str(ROOT), help="Project root for truth retrieval and report output.")
+
+    data_quality = sub.add_parser("data_quality_daily", help="Generate the data quality daily guardrail report.")
+    data_quality.add_argument("--root", default=str(ROOT), help="Project root for local evidence and report output.")
+    data_quality.add_argument("--as-of", default="", help="Optional YYYY-MM-DD date for deterministic checks.")
+
+    backtest_review = sub.add_parser("backtest_review", help="Generate the backtest review guardrail report.")
+    backtest_review.add_argument("--root", default=str(ROOT), help="Project root for local evidence and report output.")
+
+    support_triage = sub.add_parser("support_triage", help="Generate the support triage shadow-mode report.")
+    support_triage.add_argument("--root", default=str(ROOT), help="Project root for local ticket intake and report output.")
+
+    portfolio_retro = sub.add_parser("portfolio_retro_weekly", help="Generate the portfolio retro weekly report.")
+    portfolio_retro.add_argument("--root", default=str(ROOT), help="Project root for local skill outputs and report output.")
+
     develop = sub.add_parser("develop", help="Submit Developer Tool task for CEO-gated code generation.")
     develop.add_argument("--task", required=True, help="Plain-English development task.")
 
@@ -438,6 +477,74 @@ def main() -> None:
 
     if args.command == "memory_search":
         _emit(_memory_search(config=config, query=args.query, top_k=args.top_k))
+        return
+
+    if args.command == "ask_company":
+        from chief_of_staff import answer_company_question, render_company_answer  # pylint: disable=import-outside-toplevel
+
+        response = answer_company_question(question=args.question, root=Path(args.root))
+        if args.json:
+            _emit(response)
+        else:
+            print(render_company_answer(response))
+        return
+
+    if args.command == "persona_chat":
+        from persona_router import answer_persona  # pylint: disable=import-outside-toplevel
+
+        _emit(
+            answer_persona(
+                persona=args.persona,
+                message=args.message,
+                root=Path(args.root),
+                conversation_config=config.get("conversation", {}),
+            )
+        )
+        return
+
+    if args.command == "nanoclaw_shadow_write":
+        from nanoclaw_shadow_writer import write_latest_shadow_response  # pylint: disable=import-outside-toplevel
+
+        _emit(
+            write_latest_shadow_response(
+                root=Path(args.root),
+                inbox_path=args.inbox_path,
+                outbox_path=args.outbox_path,
+            )
+        )
+        return
+
+    if args.command == "risk_aggregate_daily":
+        from skill_risk_aggregate_daily import run_risk_aggregate_daily  # pylint: disable=import-outside-toplevel
+
+        _emit(run_risk_aggregate_daily(root=Path(args.root)))
+        return
+
+    if args.command == "data_quality_daily":
+        from datetime import date  # pylint: disable=import-outside-toplevel
+
+        from skill_data_quality_daily import run_data_quality_daily  # pylint: disable=import-outside-toplevel
+
+        as_of = date.fromisoformat(args.as_of) if args.as_of else None
+        _emit(run_data_quality_daily(root=Path(args.root), as_of=as_of))
+        return
+
+    if args.command == "backtest_review":
+        from skill_backtest_review import run_backtest_review  # pylint: disable=import-outside-toplevel
+
+        _emit(run_backtest_review(root=Path(args.root)))
+        return
+
+    if args.command == "support_triage":
+        from skill_support_triage import run_support_triage  # pylint: disable=import-outside-toplevel
+
+        _emit(run_support_triage(root=Path(args.root)))
+        return
+
+    if args.command == "portfolio_retro_weekly":
+        from skill_portfolio_retro_weekly import run_portfolio_retro_weekly  # pylint: disable=import-outside-toplevel
+
+        _emit(run_portfolio_retro_weekly(root=Path(args.root)))
         return
 
     if args.command == "develop":

--- a/scripts/tool_router.py
+++ b/scripts/tool_router.py
@@ -135,6 +135,7 @@ def build_parser() -> argparse.ArgumentParser:
     work_sub = work.add_subparsers(dest="work_action", required=True)
     work_sub.add_parser("status", help="Show work ledger status.")
     work_sub.add_parser("reminders", help="Show owner action reminders.")
+    work_sub.add_parser("run_next", help="Run the oldest approved work item.")
     work_show = work_sub.add_parser("show", help="Show one work item.")
     work_show.add_argument("--work-id", required=True, help="Work item id.")
     work_scan = work_sub.add_parser("scan_reviews", help="Scan review markdown into the work ledger.")
@@ -360,6 +361,7 @@ def main() -> None:
             work_reminders,
             work_status,
         )
+        from kernel.worker import run_next_work_item  # pylint: disable=import-outside-toplevel
         from kernel.work_items import (  # pylint: disable=import-outside-toplevel
             approve_work_item,
             block_work_item,
@@ -381,6 +383,10 @@ def main() -> None:
                     reminders = work_reminders(conn)
                     reminders["text"] = render_reminder_text(reminders)
                     _emit(reminders)
+                    return
+                if args.work_action == "run_next":
+                    result = run_next_work_item(conn)
+                    _emit(result)
                     return
                 if args.work_action == "show":
                     item = get_work_item(conn, args.work_id)

--- a/scripts/work.py
+++ b/scripts/work.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from kernel.db import connect  # noqa: E402
+from kernel.views import render_status_text, work_status  # noqa: E402
+from kernel.work_items import (  # noqa: E402
+    approve_work_item,
+    block_work_item,
+    create_work_item,
+    done_work_item,
+    get_work_item,
+    scan_ready_for_review_markdown,
+    start_work_item,
+)
+
+
+def _print_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Minimal AI company OS work ledger.")
+    parser.add_argument("--db", default=None, help="Optional work ledger DB path.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Show work that needs decision, execution, measurement, or unblock.")
+
+    scan = sub.add_parser("scan_reviews", help="Scan markdown files for READY FOR MA REVIEW.")
+    scan.add_argument("--root", default=str(ROOT / "finance_web_page"), help="Root directory to scan.")
+
+    create = sub.add_parser("create", help="Create a work item.")
+    create.add_argument("--title", required=True)
+    create.add_argument("--type", default="task")
+    create.add_argument("--source", default="manual")
+    create.add_argument("--owner", default="Unassigned")
+    create.add_argument("--due-at", default="")
+    create.add_argument("--needs-approval", action="store_true")
+    create.add_argument("--completion-signal", default="")
+    create.add_argument("--next-step", default="")
+
+    show = sub.add_parser("show", help="Show one work item.")
+    show.add_argument("work_id")
+
+    approve = sub.add_parser("approve", help="Approve work with execution fields.")
+    approve.add_argument("work_id")
+    approve.add_argument("--owner", required=True)
+    approve.add_argument("--due-at", required=True)
+    approve.add_argument("--completion-signal", required=True)
+    approve.add_argument("--next-step", default="")
+
+    start = sub.add_parser("start", help="Mark approved work in progress.")
+    start.add_argument("work_id")
+    start.add_argument("--note", default="")
+
+    block = sub.add_parser("block", help="Mark work blocked.")
+    block.add_argument("work_id")
+    block.add_argument("--reason", required=True)
+
+    done = sub.add_parser("done", help="Close work with result and evidence.")
+    done.add_argument("work_id")
+    done.add_argument("--result", required=True)
+    done.add_argument("--evidence", required=True)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    conn = connect(args.db)
+    try:
+        if args.command == "status":
+            print(render_status_text(work_status(conn)))
+            return 0
+        if args.command == "scan_reviews":
+            _print_json(scan_ready_for_review_markdown(conn, root=args.root))
+            return 0
+        if args.command == "create":
+            item, created = create_work_item(
+                conn,
+                title=args.title,
+                work_type=args.type,
+                source=args.source,
+                owner=args.owner,
+                due_at=args.due_at.strip() or None,
+                needs_approval=bool(args.needs_approval),
+                completion_signal=args.completion_signal.strip() or None,
+                next_step=args.next_step.strip() or None,
+            )
+            _print_json({"ok": True, "created": created, "item": item})
+            return 0
+        if args.command == "show":
+            item = get_work_item(conn, args.work_id)
+            _print_json({"ok": item is not None, "item": item})
+            return 0 if item is not None else 1
+        if args.command == "approve":
+            _print_json(
+                {
+                    "ok": True,
+                    "item": approve_work_item(
+                        conn,
+                        args.work_id,
+                        owner=args.owner,
+                        due_at=args.due_at,
+                        completion_signal=args.completion_signal,
+                        next_step=args.next_step.strip() or None,
+                    ),
+                }
+            )
+            return 0
+        if args.command == "start":
+            _print_json({"ok": True, "item": start_work_item(conn, args.work_id, note=args.note)})
+            return 0
+        if args.command == "block":
+            _print_json({"ok": True, "item": block_work_item(conn, args.work_id, args.reason)})
+            return 0
+        if args.command == "done":
+            _print_json(
+                {
+                    "ok": True,
+                    "item": done_work_item(
+                        conn,
+                        args.work_id,
+                        result=args.result,
+                        evidence=args.evidence,
+                    ),
+                }
+            )
+            return 0
+    except ValueError as exc:
+        _print_json({"ok": False, "error": str(exc)})
+        return 1
+    finally:
+        conn.close()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start_bridge.ps1
+++ b/start_bridge.ps1
@@ -6,6 +6,12 @@ $RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $EnvFile = Join-Path $RepoRoot ".env"
 $EnvLocalFile = Join-Path $RepoRoot ".env.local"
 $BridgeScript = Join-Path $RepoRoot "scripts\aiogram_bridge.py"
+$PauseFile = Join-Path $RepoRoot "PAUSE_AI_HOLDING"
+
+if (Test-Path $PauseFile) {
+    Write-Host "PAUSE_AI_HOLDING exists; not starting bridge."
+    exit 0
+}
 
 function Import-EnvFile {
     param([string]$Path)

--- a/start_bridge_safe.ps1
+++ b/start_bridge_safe.ps1
@@ -9,6 +9,7 @@ $EnvLocalFile = Join-Path $RepoRoot ".env.local"
 $LogDir      = Join-Path $RepoRoot "logs"
 $LogFile     = Join-Path $LogDir "startup_diagnostic.log"
 $OllamaExe   = "$env:LOCALAPPDATA\Programs\Ollama\ollama.exe"
+$PauseFile   = Join-Path $RepoRoot "PAUSE_AI_HOLDING"
 
 $MaxWaitSeconds = 30
 
@@ -21,6 +22,11 @@ function Write-Log($msg) {
     $line = "[$ts] $msg"
     Write-Host $line
     Add-Content -Path $LogFile -Value $line
+}
+
+if (Test-Path $PauseFile) {
+    Write-Log "[PAUSED] PAUSE_AI_HOLDING exists; not starting Ollama or bridge"
+    exit 0
 }
 
 function Import-EnvFile($Path) {

--- a/tests/test_aiogram_bridge.py
+++ b/tests/test_aiogram_bridge.py
@@ -129,6 +129,29 @@ def test_work_command_routes_to_tool_router(monkeypatch) -> None:
     assert "Decide: 1" in reply
 
 
+def test_work_reminders_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "needs_attention": True,
+                "count": 1,
+                "text": "Work reminders: 1 item(s) need owner attention.",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_work_command("/work reminders"))
+
+    assert calls == [["work", "reminders"]]
+    assert "need owner attention" in reply
+
+
 def test_work_scan_reviews_routes_to_tool_router(monkeypatch) -> None:
     calls: list[list[str]] = []
 

--- a/tests/test_aiogram_bridge.py
+++ b/tests/test_aiogram_bridge.py
@@ -82,6 +82,116 @@ def test_dev_pipeline_commands_have_restricted_action_types() -> None:
     assert aiogram_bridge._command_action_type("/work block work_123 reason") == "approval_execution_update"
     assert aiogram_bridge._command_action_type("/work done work_123 | result | evidence") == "approval_execution_update"
     assert aiogram_bridge._command_action_type("/work run_next") == "approval_execution_update"
+    assert aiogram_bridge._command_action_type("/ask_company What needs me today?") == "view_status"
+    assert aiogram_bridge._command_action_type("/risk_aggregate_daily") == "view_status"
+    assert aiogram_bridge._command_action_type("/data_quality_daily") == "view_status"
+    assert aiogram_bridge._command_action_type("/backtest_review") == "view_status"
+    assert aiogram_bridge._command_action_type("/support_triage") == "view_status"
+    assert aiogram_bridge._command_action_type("/portfolio_retro_weekly") == "view_status"
+
+
+def test_ask_company_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "answer": "You have one real decision today.",
+                "owner_need": "approve",
+                "sources": ["reports/phase3_holding_latest.json"],
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_known_command("/ask_company What needs me today?"))
+
+    assert calls == [["ask_company", "--question", "What needs me today?", "--json"]]
+    assert "You have one real decision today." in reply
+    assert "Owner need: approve" in reply
+    assert "reports/phase3_holding_latest.json" in reply
+
+
+def test_skill_bridge_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "skill": "backtest-review",
+                "status": "BLOCKED",
+                "owner_need": "none",
+                "brief": "Backtest review is BLOCKED. No reviewed candidate is approved.",
+                "markdown_path": "reports/skills/backtest-review/latest.md",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_known_command("/backtest_review"))
+
+    assert calls == [["backtest_review"]]
+    assert "backtest-review is BLOCKED" in reply
+    assert "No reviewed candidate is approved" in reply
+    assert "reports/skills/backtest-review/latest.md" in reply
+
+
+def test_support_triage_bridge_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "skill": "support-triage",
+                "status": "BLOCKED",
+                "owner_need": "none",
+                "brief": "Support triage is BLOCKED. No local support ticket source found.",
+                "markdown_path": "reports/skills/support-triage/latest.md",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_known_command("/support_triage"))
+
+    assert calls == [["support_triage"]]
+    assert "support-triage is BLOCKED" in reply
+    assert "No local support ticket source found" in reply
+
+
+def test_portfolio_retro_bridge_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "skill": "portfolio-retro-weekly",
+                "status": "GREEN",
+                "owner_need": "none",
+                "brief": "Weekly retro is GREEN.",
+                "markdown_path": "reports/skills/portfolio-retro-weekly/latest.md",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_known_command("/portfolio_retro_weekly"))
+
+    assert calls == [["portfolio_retro_weekly"]]
+    assert "portfolio-retro-weekly is GREEN" in reply
+    assert "Weekly retro is GREEN" in reply
 
 
 def test_loop_command_routes_to_tool_router(monkeypatch) -> None:

--- a/tests/test_aiogram_bridge.py
+++ b/tests/test_aiogram_bridge.py
@@ -153,6 +153,133 @@ def test_work_scan_reviews_routes_to_tool_router(monkeypatch) -> None:
     assert "Work Ledger" in reply
 
 
+def test_work_approve_command_requires_owner_due_and_signal(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "item": {
+                    "id": "work_123",
+                    "title": "Review closure",
+                    "status": "APPROVED",
+                    "owner": "MA",
+                    "due_at": "2026-05-08T18:00:00+00:00",
+                    "completion_signal": "Signed review note exists.",
+                    "next_step": "Start execution.",
+                    "evidence": [],
+                },
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(
+        aiogram_bridge._handle_work_command(
+            "/work approve work_123 | MA | 2026-05-08T18:00:00+00:00 | Signed review note exists."
+        )
+    )
+
+    assert calls == [
+        [
+            "work",
+            "approve",
+            "--work-id",
+            "work_123",
+            "--owner",
+            "MA",
+            "--due-at",
+            "2026-05-08T18:00:00+00:00",
+            "--completion-signal",
+            "Signed review note exists.",
+        ]
+    ]
+    assert "Approved: `work_123` [APPROVED]" in reply
+    assert "Owner: MA" in reply
+
+
+def test_work_done_command_requires_result_and_evidence(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "item": {
+                    "id": "work_123",
+                    "title": "Review closure",
+                    "status": "DONE",
+                    "owner": "MA",
+                    "due_at": "2026-05-08T18:00:00+00:00",
+                    "completion_signal": "Signed review note exists.",
+                    "next_step": "Closed.",
+                    "evidence": [{"summary": "reports/review.md"}],
+                },
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(
+        aiogram_bridge._handle_work_command("/work done work_123 | Review accepted | reports/review.md")
+    )
+
+    assert calls == [
+        [
+            "work",
+            "done",
+            "--work-id",
+            "work_123",
+            "--result",
+            "Review accepted",
+            "--evidence",
+            "reports/review.md",
+        ]
+    ]
+    assert "Closed: `work_123` [DONE]" in reply
+    assert "Evidence: 1" in reply
+
+
+def test_work_start_and_block_commands_route_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "item": {
+                    "id": sub_args[3],
+                    "title": "Review closure",
+                    "status": "IN_PROGRESS" if sub_args[1] == "start" else "BLOCKED",
+                    "owner": "MA",
+                    "due_at": "2026-05-08T18:00:00+00:00",
+                    "completion_signal": "Signed review note exists.",
+                    "next_step": "Complete work." if sub_args[1] == "start" else "Blocked: waiting on credentials",
+                    "evidence": [],
+                },
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    start_reply = asyncio.run(aiogram_bridge._handle_work_command("/work start work_123 review started"))
+    block_reply = asyncio.run(aiogram_bridge._handle_work_command("/work block work_123 waiting on credentials"))
+
+    assert calls == [
+        ["work", "start", "--work-id", "work_123", "--note", "review started"],
+        ["work", "block", "--work-id", "work_123", "--reason", "waiting on credentials"],
+    ]
+    assert "Started: `work_123` [IN_PROGRESS]" in start_reply
+    assert "Blocked: `work_123` [BLOCKED]" in block_reply
+
+
 def test_simulate_text_requires_explicit_identity(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("TELEGRAM_OWNER_CHAT_ID", raising=False)
     monkeypatch.delenv("TELEGRAM_OWNER_USER_ID", raising=False)

--- a/tests/test_aiogram_bridge.py
+++ b/tests/test_aiogram_bridge.py
@@ -73,6 +73,8 @@ def test_dev_pipeline_commands_have_restricted_action_types() -> None:
     assert aiogram_bridge._command_action_type("/approve_init_1234") == "develop_decision"
     assert aiogram_bridge._command_action_type("/boardroom ask trading status") == "view_status"
     assert aiogram_bridge._command_action_type("/loop new improve reporting") == "view_status"
+    assert aiogram_bridge._command_action_type("/work") == "view_status"
+    assert aiogram_bridge._command_action_type("/work scan_reviews") == "view_status"
 
 
 def test_loop_command_routes_to_tool_router(monkeypatch) -> None:
@@ -102,6 +104,53 @@ def test_loop_command_routes_to_tool_router(monkeypatch) -> None:
     assert calls == [["loop", "new", "--goal", "Improve reporting"]]
     assert "Loop `loop_0001` is GOAL_CAPTURED" in reply
     assert "Gather evidence" in reply
+
+
+def test_work_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "counts": {"open": 1, "pending_approval": 1, "approved": 0, "in_progress": 0},
+                "text": "Work Ledger\n- Open: 1 | Decide: 1 | Execute: 0",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_work_command("/work"))
+
+    assert calls == [["work", "status"]]
+    assert "Work Ledger" in reply
+    assert "Decide: 1" in reply
+
+
+def test_work_scan_reviews_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "created": 2,
+                "existing": 1,
+                "text": "Work Ledger\n- Open: 3 | Decide: 2 | Execute: 0",
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_work_command("/work scan_reviews"))
+
+    assert calls == [["work", "scan_reviews"]]
+    assert "Review scan complete: created 2, existing 1." in reply
+    assert "Work Ledger" in reply
 
 
 def test_simulate_text_requires_explicit_identity(tmp_path, monkeypatch) -> None:

--- a/tests/test_aiogram_bridge.py
+++ b/tests/test_aiogram_bridge.py
@@ -75,6 +75,13 @@ def test_dev_pipeline_commands_have_restricted_action_types() -> None:
     assert aiogram_bridge._command_action_type("/loop new improve reporting") == "view_status"
     assert aiogram_bridge._command_action_type("/work") == "view_status"
     assert aiogram_bridge._command_action_type("/work scan_reviews") == "view_status"
+    assert aiogram_bridge._command_action_type("/work reminders") == "view_status"
+    assert aiogram_bridge._command_action_type("/work show work_123") == "view_status"
+    assert aiogram_bridge._command_action_type("/work approve work_123 | MA | due | signal") == "approval_execution_update"
+    assert aiogram_bridge._command_action_type("/work start work_123") == "approval_execution_update"
+    assert aiogram_bridge._command_action_type("/work block work_123 reason") == "approval_execution_update"
+    assert aiogram_bridge._command_action_type("/work done work_123 | result | evidence") == "approval_execution_update"
+    assert aiogram_bridge._command_action_type("/work run_next") == "approval_execution_update"
 
 
 def test_loop_command_routes_to_tool_router(monkeypatch) -> None:
@@ -150,6 +157,38 @@ def test_work_reminders_command_routes_to_tool_router(monkeypatch) -> None:
 
     assert calls == [["work", "reminders"]]
     assert "need owner attention" in reply
+
+
+def test_work_run_next_command_routes_to_tool_router(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def _run_router(sub_args: list[str], timeout_sec: int = 300) -> dict[str, Any]:
+        calls.append(sub_args)
+        return {
+            "ok": True,
+            "payload": {
+                "ok": True,
+                "ran": True,
+                "outcome": "blocked",
+                "item": {
+                    "id": "work_123",
+                    "title": "Manual review",
+                    "status": "BLOCKED",
+                    "owner": "MA",
+                    "due_at": "2026-05-08T18:00:00+00:00",
+                    "completion_signal": "Review note exists.",
+                    "next_step": "Blocked: No automated executor is registered.",
+                    "evidence": [],
+                },
+            },
+        }
+
+    monkeypatch.setattr(aiogram_bridge, "_run_tool_router", _run_router)
+
+    reply = asyncio.run(aiogram_bridge._handle_work_command("/work run_next"))
+
+    assert calls == [["work", "run_next"]]
+    assert "Worker result: `work_123` [BLOCKED]" in reply
 
 
 def test_work_scan_reviews_routes_to_tool_router(monkeypatch) -> None:

--- a/tests/test_chief_of_staff.py
+++ b/tests/test_chief_of_staff.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from chief_of_staff import answer_company_question, render_company_answer  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_answer_company_question_summarizes_owner_needs_naturally(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "RED",
+                "risks": ["Forecast attainment is RED."],
+                "actions": ["Prioritize monetization levers."],
+            },
+            "base_summary": {"websites_up": 2, "websites_total": 2, "pnl_total": 0.0, "trades_total": 0},
+        },
+    )
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [
+                    {
+                        "approval_id": "board_test",
+                        "topic": "Company KPI: Forecast attainment",
+                        "decision": "Run monetization recovery.",
+                        "owner": "holding",
+                        "priority": "RED",
+                    }
+                ]
+            },
+            "decisions": {},
+        },
+    )
+
+    response = answer_company_question("What needs me today?", root=tmp_path)
+
+    assert "You have one real decision today" in response["answer"]
+    assert "one approval" in response["answer"].lower()
+    assert "Forecast attainment" in response["answer"]
+    assert response["owner_need"] == "approve"
+    assert "reports/phase3_holding_latest.json" in response["sources"]
+
+
+def test_answer_company_question_handles_trading_status_from_truth(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase2_divisions_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "divisions": [
+                {
+                    "division": "trading",
+                    "status": "yellow",
+                    "scorecard": {
+                        "status": "AMBER",
+                        "items": [
+                            {
+                                "metric": "MT5 cycle freshness",
+                                "status": "AMBER",
+                                "actual": "4h",
+                                "target": "<= 180m",
+                                "action": "Verify runtime events are advancing.",
+                            }
+                        ],
+                    },
+                }
+            ],
+        },
+    )
+
+    response = answer_company_question("Why is trading yellow?", root=tmp_path)
+
+    assert "Trading is AMBER" in response["answer"]
+    assert "MT5 cycle freshness" in response["answer"]
+    assert "Verify runtime events are advancing" in response["answer"]
+    assert response["truth_state"] == "known"
+
+
+def test_answer_company_question_uses_data_quality_skill_for_trading_readiness(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {
+            "status": "BLOCKED",
+            "brief": "Trading data quality is BLOCKED. No MT5 daily evidence summary found.",
+            "checks": [],
+        },
+    )
+
+    response = answer_company_question("Why is trading yellow?", root=tmp_path)
+
+    assert "Trading data-quality readiness is BLOCKED" in response["answer"]
+    assert "No MT5 daily evidence summary found" in response["answer"]
+
+
+def test_answer_company_question_uses_backtest_review_for_forward_test_questions(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "status": "BLOCKED",
+            "brief": "Backtest review is BLOCKED. No reviewed candidate is approved.",
+            "required_next_action": "Do not move any reviewed strategy to forward-test.",
+        },
+    )
+
+    response = answer_company_question("Can the strategy move to forward-test?", root=tmp_path)
+
+    assert "Backtest review is BLOCKED" in response["answer"]
+    assert "Do not move any reviewed strategy" in response["answer"]
+    assert response["owner_need"] == "none"
+
+
+def test_answer_company_question_uses_support_triage_for_support_questions(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "support-triage" / "latest.json",
+        {
+            "status": "AMBER",
+            "brief": "Support triage found 2 ticket(s): 1 draft(s) and 1 escalation(s).",
+        },
+    )
+
+    response = answer_company_question("What is happening in support?", root=tmp_path)
+
+    assert "Support triage is AMBER" in response["answer"]
+    assert "2 ticket" in response["answer"]
+    assert response["owner_need"] == "approve"
+
+
+def test_answer_company_question_refuses_missing_truth(tmp_path: Path) -> None:
+    response = answer_company_question("What needs me today?", root=tmp_path)
+
+    assert "I do not have current company evidence" in response["answer"]
+    assert response["truth_state"] == "unknown"
+    assert response["owner_need"] == "refresh"
+
+
+def test_answer_company_question_shows_evidence_when_requested(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {"status": "GREEN", "risks": [], "actions": []},
+        },
+    )
+
+    response = answer_company_question("Show evidence for what needs me today", root=tmp_path)
+
+    assert "Evidence:" in response["answer"]
+    assert "reports/phase3_holding_latest.json" in response["answer"]
+
+
+def test_render_company_answer_is_conversational_not_json(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "AMBER",
+                "risks": ["Growth is below target."],
+                "actions": ["Review weekly analytics."],
+            },
+        },
+    )
+
+    response = answer_company_question("What needs me today?", root=tmp_path)
+    text = render_company_answer(response)
+
+    assert text.startswith("You")
+    assert '"ok"' not in text
+    assert "Sources:" not in text

--- a/tests/test_company_loop.py
+++ b/tests/test_company_loop.py
@@ -130,6 +130,33 @@ def test_approval_auto_starts_loop_for_md_execution(tmp_path, monkeypatch) -> No
     assert loop["history"][-1]["event"] == "IN_PROGRESS"
 
 
+def test_loop_report_includes_execution_plan(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(company_loop, "ROOT", tmp_path)
+    config = _config(tmp_path)
+    loop_id = company_loop.new_loop(config, goal="Run FTH metric refresh")["loop"]["loop_id"]
+    state_path = tmp_path / "state" / "company_loops.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["loops"][0]["execution_plan"] = [
+        {
+            "task": "Refresh FreeTraderHub metric source",
+            "owner": "Commercial",
+            "due_at_utc": "2026-05-08T18:00:00+00:00",
+            "status": "TODO",
+            "completion_signal": "Updated metric source and CEO heartbeat attached.",
+        }
+    ]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    company_loop.show_loop(config, loop_id)
+
+    report = tmp_path / "reports" / "company_loops" / "loop_0001.md"
+    text = report.read_text(encoding="utf-8")
+    assert "## Execution Plan" in text
+    assert "Refresh FreeTraderHub metric source" in text
+    assert "Owner: Commercial" in text
+    assert "Due UTC: 2026-05-08T18:00:00+00:00" in text
+
+
 def test_reapproval_note_does_not_replace_existing_approved_action(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(company_loop, "ROOT", tmp_path)
     config = _config(tmp_path)

--- a/tests/test_nanoclaw_status.py
+++ b/tests/test_nanoclaw_status.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from nanoclaw_status import compute_status  # noqa: E402
+import persona_verbalizer  # noqa: E402
+
+
+def _write_log(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def test_compute_status_reports_accept_rate_per_persona(tmp_path: Path) -> None:
+    log = tmp_path / "state" / "nanoclaw_live_log.jsonl"
+    _write_log(
+        log,
+        [{"persona": "chief-of-staff", "packet_id": str(i), "accepted": i < 4, "reason": "ok"} for i in range(5)]
+        + [{"persona": "risk-officer", "packet_id": str(i), "accepted": False, "reason": "empty_answer"} for i in range(3)],
+    )
+
+    result = compute_status(
+        log_path=log,
+        window=10,
+        min_accept_rate=0.80,
+        personas={"chief-of-staff": "live", "risk-officer": "shadow", "growth-lead": "shadow"},
+    )
+
+    by_persona = {p["persona"]: p for p in result["personas"]}
+    assert by_persona["chief-of-staff"]["accepted"] == 4
+    assert by_persona["chief-of-staff"]["accept_rate"] == 0.8
+    # window not satisfied (only 5 records, need 10) so gate is not met
+    assert by_persona["chief-of-staff"]["meets_gate"] is False
+    assert by_persona["risk-officer"]["accept_rate"] == 0.0
+    assert by_persona["growth-lead"]["window_size"] == 0
+    assert by_persona["growth-lead"]["current_mode"] == "shadow"
+
+
+def test_compute_status_gate_passes_when_window_and_rate_met(tmp_path: Path) -> None:
+    log = tmp_path / "state" / "nanoclaw_live_log.jsonl"
+    _write_log(
+        log,
+        [{"persona": "chief-of-staff", "packet_id": str(i), "accepted": True, "reason": "ok"} for i in range(50)],
+    )
+
+    result = compute_status(log_path=log, window=50, min_accept_rate=0.80, personas={"chief-of-staff": "shadow"})
+    cof = next(p for p in result["personas"] if p["persona"] == "chief-of-staff")
+    assert cof["accept_rate"] == 1.0
+    assert cof["meets_gate"] is True
+
+
+def test_run_verbalizers_appends_live_log(monkeypatch, tmp_path: Path) -> None:
+    import urllib.request
+
+    class _Resp:
+        def __init__(self, body): self._b = body
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self._b
+
+    def _ok(req, timeout=20):
+        return _Resp(json.dumps({"response": "Welcome back."}).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _ok)
+
+    packet = {
+        "persona": "chief-of-staff",
+        "display_name": "Chief of Staff",
+        "intent": "status",
+        "packet_id": "abc123",
+        "message": "hi",
+        "evidence": [{"status": "RED", "brief": "Forecast attainment is RED."}],
+    }
+    conv = {
+        "nanoclaw": {
+            "mode": "shadow",
+            "personas": {"chief-of-staff": "live"},
+            "live_log_path": "state/nanoclaw_live_log.jsonl",
+        }
+    }
+    full = {"phase2": {"ollama_model": "llama3.2:latest"}}
+
+    result = persona_verbalizer.run_verbalizers(packet, config=conv, root=tmp_path, full_config=full)
+    assert result["primary"]["provider"] == "nanoclaw_live"
+
+    log_path = tmp_path / "state" / "nanoclaw_live_log.jsonl"
+    assert log_path.exists()
+    records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert records == [
+        {"accepted": True, "intent": "status", "packet_id": "abc123", "persona": "chief-of-staff", "reason": "ok"}
+    ]

--- a/tests/test_operating_room_server.py
+++ b/tests/test_operating_room_server.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import operating_room_server  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_operating_room_server_persona_chat_endpoint(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "support-triage" / "latest.json",
+        {
+            "skill": "support-triage",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Support triage is BLOCKED. No local support ticket source found.",
+        },
+    )
+    original_root = operating_room_server.ROOT
+    original_config_path = operating_room_server.CONFIG_PATH
+    operating_room_server.ROOT = tmp_path
+    operating_room_server.CONFIG_PATH = tmp_path / "config" / "projects.yaml"
+    _write_json(operating_room_server.CONFIG_PATH, {"conversation": {"provider": "deterministic_fallback"}})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), operating_room_server.OperatingRoomHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        body = json.dumps({"persona": "support", "message": "Any customers angry?"}).encode("utf-8")
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/api/persona-chat",
+            data=body,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        operating_room_server.ROOT = original_root
+        operating_room_server.CONFIG_PATH = original_config_path
+
+    assert payload["ok"] is True
+    assert payload["persona"] == "support-lead"
+    assert payload["no_model_calls"] is True
+    assert payload["truth_packet"]["schema_version"] == "persona_truth_packet.v1"
+    assert payload["verbalizer"]["provider"] == "deterministic_fallback"
+    assert "No local support ticket source found" in payload["answer"]
+
+
+def test_operating_room_server_shadow_write_endpoint(tmp_path: Path) -> None:
+    inbox = tmp_path / "state" / "nanoclaw_shadow_inbox.jsonl"
+    inbox.parent.mkdir(parents=True, exist_ok=True)
+    inbox.write_text(
+        json.dumps(
+            {
+                "type": "nanoclaw_shadow_request",
+                "packet_id": "packet_ui",
+                "packet": {
+                    "packet_id": "packet_ui",
+                    "persona": "chief-of-staff",
+                    "intent": "role",
+                    "evidence": [],
+                    "unknowns": [],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original_root = operating_room_server.ROOT
+    operating_room_server.ROOT = tmp_path
+    server = ThreadingHTTPServer(("127.0.0.1", 0), operating_room_server.OperatingRoomHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/api/nanoclaw-shadow-write",
+            data=b"{}",
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        operating_room_server.ROOT = original_root
+
+    assert payload["ok"] is True
+    assert payload["packet_id"] == "packet_ui"
+    assert (tmp_path / "state" / "nanoclaw_shadow_outbox.jsonl").exists()

--- a/tests/test_operating_room_snapshot.py
+++ b/tests/test_operating_room_snapshot.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from operating_room_snapshot import build_operating_room_snapshot  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_build_operating_room_snapshot_has_four_read_only_views(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "The company is RED.",
+        },
+    )
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [
+                    {
+                        "approval_id": "board_1",
+                        "topic": "Company KPI",
+                        "priority": "RED",
+                        "decision": "Focus execution.",
+                    }
+                ]
+            }
+        },
+    )
+    memory_path = tmp_path / "memory" / "vector_store.jsonl"
+    memory_path.parent.mkdir(parents=True, exist_ok=True)
+    memory_path.write_text(
+        json.dumps({"text": "Owner prefers deterministic openings.", "metadata": {"type": "decision"}}) + "\n",
+        encoding="utf-8",
+    )
+
+    snapshot = build_operating_room_snapshot(root=tmp_path)
+
+    assert snapshot["ok"] is True
+    assert set(snapshot["views"]) == {"today", "approvals", "memory", "personas"}
+    assert snapshot["views"]["today"]["status"] == "RED"
+    assert snapshot["views"]["approvals"]["pending_count"] == 1
+    assert snapshot["views"]["memory"]["sample_count"] == 1
+    assert snapshot["views"]["personas"]["personas"][0]["name"] == "Chief of Staff"
+    assert (tmp_path / "operating-room" / "snapshot.json").exists()
+
+
+def test_build_operating_room_snapshot_is_honest_when_sources_are_missing(tmp_path: Path) -> None:
+    snapshot = build_operating_room_snapshot(root=tmp_path)
+
+    assert snapshot["views"]["today"]["status"] == "UNKNOWN"
+    assert snapshot["views"]["today"]["items"][0]["status"] == "UNKNOWN"
+    assert snapshot["views"]["approvals"]["pending_count"] == 0
+    assert snapshot["views"]["memory"]["sample_count"] == 0

--- a/tests/test_org_truth_retriever.py
+++ b/tests/test_org_truth_retriever.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from org_truth_retriever import collect_truth_bundle  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_collect_truth_bundle_loads_company_status_and_approvals(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "RED",
+                "risks": ["Forecast attainment is RED."],
+                "actions": ["Prioritize monetization levers."],
+            },
+            "base_summary": {"websites_up": 2, "websites_total": 2, "pnl_total": 0.0, "trades_total": 0},
+        },
+    )
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [
+                    {
+                        "approval_id": "board_test",
+                        "topic": "Company KPI: Forecast attainment",
+                        "decision": "Run monetization recovery.",
+                        "owner": "holding",
+                        "priority": "RED",
+                    }
+                ]
+            },
+            "decisions": {},
+        },
+    )
+
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.company_status == "RED"
+    assert bundle.company_risks == ["Forecast attainment is RED."]
+    assert bundle.pending_approvals[0]["approval_id"] == "board_test"
+    assert any(source.path == "reports/phase3_holding_latest.json" for source in bundle.sources)
+
+
+def test_collect_truth_bundle_returns_unknowns_when_reports_are_missing(tmp_path: Path) -> None:
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.company_status == "UNKNOWN"
+    assert bundle.truth_state == "unknown"
+    assert bundle.pending_approvals == []
+    assert bundle.company_risks == []
+
+
+def test_collect_truth_bundle_extracts_trading_scorecard(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase2_divisions_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "divisions": [
+                {
+                    "division": "trading",
+                    "status": "amber",
+                    "scorecard": {
+                        "status": "AMBER",
+                        "items": [
+                            {
+                                "metric": "MT5 cycle freshness",
+                                "status": "AMBER",
+                                "actual": "4h",
+                                "target": "<= 180m",
+                                "action": "Verify runtime events are advancing.",
+                            }
+                        ],
+                        "actions": ["Verify runtime events are advancing."],
+                    },
+                }
+            ],
+        },
+    )
+
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.trading_status == "AMBER"
+    assert bundle.trading_issues[0]["metric"] == "MT5 cycle freshness"
+    assert bundle.trading_actions == ["Verify runtime events are advancing."]
+
+
+def test_collect_truth_bundle_loads_data_quality_skill_output(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {
+            "status": "BLOCKED",
+            "brief": "Trading data quality is BLOCKED. No MT5 daily evidence summary found.",
+            "checks": [],
+        },
+    )
+
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.data_quality_status == "BLOCKED"
+    assert "No MT5 daily evidence summary found" in bundle.data_quality_brief
+    assert "reports/skills/data-quality-daily/latest.json" in bundle.source_paths()
+
+
+def test_collect_truth_bundle_loads_backtest_review_skill_output(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "status": "BLOCKED",
+            "brief": "Backtest review is BLOCKED. No reviewed candidate is approved.",
+        },
+    )
+
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.backtest_review_status == "BLOCKED"
+    assert "No reviewed candidate is approved" in bundle.backtest_review_brief
+    assert "reports/skills/backtest-review/latest.json" in bundle.source_paths()
+
+
+def test_collect_truth_bundle_loads_support_triage_skill_output(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "support-triage" / "latest.json",
+        {
+            "status": "BLOCKED",
+            "brief": "Support triage is BLOCKED. No local support ticket source found.",
+        },
+    )
+
+    bundle = collect_truth_bundle(tmp_path)
+
+    assert bundle.support_triage_status == "BLOCKED"
+    assert "No local support ticket source found" in bundle.support_triage_brief
+    assert "reports/skills/support-triage/latest.json" in bundle.source_paths()

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -425,3 +425,69 @@ def test_support_lead_reports_missing_inbox_source(tmp_path: Path) -> None:
     assert response["persona"] == "support-lead"
     assert "No local support ticket source found" in response["answer"]
     assert response["truth_state"] == "known"
+
+
+def test_nanoclaw_live_returns_model_text_when_ollama_responds(monkeypatch) -> None:
+    import io
+    import urllib.request
+
+    import persona_verbalizer
+
+    captured = {}
+
+    class _FakeResp:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return self._body
+
+    def _fake_urlopen(req, timeout=20):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResp(json.dumps({"response": "Welcome back, James. Forecast attainment is RED."}).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+
+    packet = {
+        "persona": "chief-of-staff",
+        "display_name": "Chief of Staff",
+        "intent": "status",
+        "message": "what needs me?",
+        "evidence": [{"status": "RED", "brief": "Forecast attainment is RED."}],
+    }
+    config = {"phase2": {"ollama_model": "llama3.2:latest", "ollama_base_url": "http://127.0.0.1:11434"}}
+
+    out = persona_verbalizer.nanoclaw_live_verbalize(packet, config)
+
+    assert out["provider"] == "nanoclaw_live"
+    assert out["no_model_calls"] is False
+    assert out["answer"].startswith("Welcome back, James.")
+    assert captured["url"].endswith("/api/generate")
+    assert captured["body"]["model"] == "llama3.2:latest"
+    assert captured["body"]["stream"] is False
+
+
+def test_nanoclaw_live_returns_empty_answer_when_ollama_unreachable(monkeypatch) -> None:
+    import urllib.error
+    import urllib.request
+
+    import persona_verbalizer
+
+    def _boom(req, timeout=20):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+    out = persona_verbalizer.nanoclaw_live_verbalize({"persona": "chief-of-staff", "intent": "status"}, {})
+    assert out["provider"] == "nanoclaw_live"
+    assert out["answer"] == ""
+    verdict = persona_verbalizer.verify_verbalizer_output(out)
+    assert verdict["accepted"] is False
+    assert verdict["reason"] == "empty_answer"

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -119,6 +119,48 @@ def test_chief_of_staff_reply_avoids_report_row_language(tmp_path: Path) -> None
     assert response["answer"].count("I would focus there first") == 1
 
 
+def test_chief_of_staff_green_state_drops_urgency_framing(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "GREEN",
+            "owner_need": "none",
+            "brief": "Company is GREEN. All KPIs within target.",
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "GREEN",
+            "owner_need": "none",
+            "brief": "Backtest review is current.",
+        },
+    )
+
+    response = answer_persona(persona="chief", message="what needs me?", root=tmp_path)
+
+    assert response["answer"].startswith("Welcome back.")
+    assert "I would focus there first" not in response["answer"]
+    assert "behind that" not in response["answer"]
+    assert response["evidence"][0]["status"] == "GREEN"
+    assert _clean_brief_for_test(response["evidence"][0]["brief"]) in response["answer"]
+
+
+def _clean_brief_for_test(brief: str) -> str:
+    cleaned = brief.strip()
+    for prefix in (
+        "Backtest review is BLOCKED. ",
+        "Portfolio retro is BLOCKED. ",
+        "Support triage is BLOCKED. ",
+        "The company is RED in the latest stored CEO report. ",
+    ):
+        if cleaned.startswith(prefix):
+            return cleaned.removeprefix(prefix)
+    return cleaned
+
+
 def test_chief_of_staff_answers_role_question_without_repeating_status(tmp_path: Path) -> None:
     _write_json(
         tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from persona_router import answer_persona, build_truth_packet  # noqa: E402
+from nanoclaw_shadow_writer import write_latest_shadow_response  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_chief_of_staff_answers_free_text_from_org_truth(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [
+                    {
+                        "approval_id": "board_1",
+                        "topic": "Company KPI: Forecast attainment",
+                        "priority": "RED",
+                    }
+                ]
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Forecast attainment is RED.",
+        },
+    )
+
+    response = answer_persona(
+        persona="chief of staff",
+        message="I just got back. What actually needs my attention and why?",
+        root=tmp_path,
+    )
+
+    assert response["ok"] is True
+    assert response["persona"] == "chief-of-staff"
+    assert response["truth_state"] == "known"
+    assert response["owner_need"] == "approve"
+    assert "Forecast attainment is RED" in response["answer"]
+    assert "one approval" in response["answer"]
+    assert "state/board_approval_decisions.json" in response["sources"]
+
+
+def test_persona_answer_carries_evidence_without_chat_memory(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Company is RED because forecast attainment is 4.1%.",
+        },
+    )
+
+    response = answer_persona(
+        persona="chief",
+        message="Talk to me like my chief of staff. What matters?",
+        root=tmp_path,
+    )
+
+    assert response["grounding_mode"] == "deterministic_local_truth"
+    assert response["no_model_calls"] is True
+    assert response["evidence"][0]["source"] == "reports/skills/risk-aggregate-daily/latest.json"
+    assert response["evidence"][0]["status"] == "RED"
+    assert response["evidence"][0]["brief"] == "Company is RED because forecast attainment is 4.1%."
+    assert "I would focus there first" in response["answer"]
+
+
+def test_chief_of_staff_reply_avoids_report_row_language(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [{"approval_id": "board_1", "topic": "Company KPI", "priority": "RED"}]
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Backtest review is BLOCKED. No out-of-sample evidence.",
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "support-triage" / "latest.json",
+        {
+            "skill": "support-triage",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Support triage is BLOCKED. No local support ticket source found.",
+        },
+    )
+
+    response = answer_persona(persona="chief", message="Hi", root=tmp_path)
+
+    assert response["answer"].startswith("Welcome back.")
+    assert "backtest-review:" not in response["answer"]
+    assert "issue records" not in response["answer"]
+    assert "I would focus there first" in response["answer"]
+    assert response["answer"].count("I would focus there first") == 1
+
+
+def test_chief_of_staff_answers_role_question_without_repeating_status(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Backtest review is BLOCKED. No out-of-sample evidence.",
+        },
+    )
+
+    response = answer_persona(persona="chief", message="what do you do?", root=tmp_path)
+
+    assert "I help you run the company" in response["answer"]
+    assert "what needs your attention" in response["answer"]
+    assert "No out-of-sample evidence" not in response["answer"]
+    assert response["intent"] == "role"
+
+
+def test_truth_packet_is_the_nanoclaw_boundary(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {"board_snapshot": {"approvals": [{"approval_id": "board_1", "topic": "Company KPI"}]}},
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Company is RED because forecast attainment is 4.1%.",
+        },
+    )
+
+    packet = build_truth_packet(persona="chief", message="what needs me?", root=tmp_path)
+
+    assert packet["schema_version"] == "persona_truth_packet.v1"
+    assert packet["packet_id"]
+    assert packet["persona"] == "chief-of-staff"
+    assert packet["intent"] == "status"
+    assert packet["approvals_count"] == 1
+    assert packet["policy"]["allowed_claim_source"] == "truth_packet_only"
+    assert packet["policy"]["no_tool_calls"] is True
+    assert packet["policy"]["no_file_reads"] is True
+    assert packet["policy"]["no_writes"] is True
+    assert packet["sources"] == [
+        "state/board_approval_decisions.json",
+        "reports/skills/risk-aggregate-daily/latest.json",
+    ]
+
+
+def test_nanoclaw_shadow_is_recorded_without_changing_live_answer(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Company is RED because forecast attainment is 4.1%.",
+        },
+    )
+    packet = build_truth_packet(persona="chief", message="what needs me?", root=tmp_path)
+    shadow_path = tmp_path / "state" / "nanoclaw_shadow_outbox.jsonl"
+    shadow_path.parent.mkdir(parents=True, exist_ok=True)
+    shadow_path.write_text(
+        json.dumps(
+            {
+                "packet_id": packet["packet_id"],
+                "persona": "chief-of-staff",
+                "intent": "status",
+                "answer": "Morning. The forecast miss is the first thing I would look at.",
+                "unsupported_claims": [],
+                "confidence": "medium",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    response = answer_persona(
+        persona="chief",
+        message="what needs me?",
+        root=tmp_path,
+        conversation_config={
+            "provider": "deterministic_fallback",
+            "nanoclaw": {
+                "mode": "shadow",
+                "shadow_outbox_path": "state/nanoclaw_shadow_outbox.jsonl",
+            },
+        },
+    )
+
+    assert response["verbalizer"]["provider"] == "deterministic_fallback"
+    assert "Forecast attainment" in response["answer"] or "forecast attainment" in response["answer"]
+    assert response["shadow_verbalizer"]["provider"] == "nanoclaw_shadow"
+    assert response["shadow_verbalizer"]["accepted"] is True
+    assert response["shadow_verbalizer"]["answer"] == "Morning. The forecast miss is the first thing I would look at."
+
+
+def test_nanoclaw_shadow_rejects_unsupported_claims(tmp_path: Path) -> None:
+    packet = build_truth_packet(persona="chief", message="what needs me?", root=tmp_path)
+    shadow_path = tmp_path / "state" / "nanoclaw_shadow_outbox.jsonl"
+    shadow_path.parent.mkdir(parents=True, exist_ok=True)
+    shadow_path.write_text(
+        json.dumps(
+            {
+                "packet_id": packet["packet_id"],
+                "persona": "chief-of-staff",
+                "intent": "status",
+                "answer": "Revenue is fixed.",
+                "unsupported_claims": ["Revenue is fixed."],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    response = answer_persona(
+        persona="chief",
+        message="what needs me?",
+        root=tmp_path,
+        conversation_config={
+            "provider": "deterministic_fallback",
+            "nanoclaw": {
+                "mode": "shadow",
+                "shadow_outbox_path": "state/nanoclaw_shadow_outbox.jsonl",
+            },
+        },
+    )
+
+    assert response["shadow_verbalizer"]["provider"] == "nanoclaw_shadow"
+    assert response["shadow_verbalizer"]["accepted"] is False
+    assert response["shadow_verbalizer"]["reason"] == "unsupported_claims"
+
+
+def test_nanoclaw_shadow_mode_writes_truth_packet_inbox(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Company is RED because forecast attainment is 4.1%.",
+        },
+    )
+
+    response = answer_persona(
+        persona="chief",
+        message="what needs me?",
+        root=tmp_path,
+        conversation_config={
+            "provider": "deterministic_fallback",
+            "nanoclaw": {
+                "mode": "shadow",
+                "shadow_inbox_path": "state/nanoclaw_shadow_inbox.jsonl",
+                "shadow_outbox_path": "state/nanoclaw_shadow_outbox.jsonl",
+            },
+        },
+    )
+
+    inbox_path = tmp_path / "state" / "nanoclaw_shadow_inbox.jsonl"
+    rows = [json.loads(line) for line in inbox_path.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["packet"]["packet_id"] == response["truth_packet"]["packet_id"]
+    assert rows[-1]["packet"]["policy"]["allowed_claim_source"] == "truth_packet_only"
+    assert response["shadow_verbalizer"]["reason"] == "no_shadow_output"
+
+
+def test_nanoclaw_shadow_writer_roundtrip_is_shadow_only(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Company is RED because forecast attainment is 4.1%.",
+        },
+    )
+    config = {
+        "provider": "deterministic_fallback",
+        "nanoclaw": {
+            "mode": "shadow",
+            "shadow_inbox_path": "state/nanoclaw_shadow_inbox.jsonl",
+            "shadow_outbox_path": "state/nanoclaw_shadow_outbox.jsonl",
+        },
+    }
+
+    first = answer_persona(persona="chief", message="what needs me?", root=tmp_path, conversation_config=config)
+    write_result = write_latest_shadow_response(root=tmp_path)
+    second = answer_persona(persona="chief", message="what needs me?", root=tmp_path, conversation_config=config)
+
+    assert write_result["ok"] is True
+    assert second["answer"] == first["answer"]
+    assert second["shadow_verbalizer"]["accepted"] is True
+    assert second["shadow_verbalizer"]["answer"]
+    assert second["shadow_verbalizer"]["provider"] == "nanoclaw_shadow"
+
+
+def test_risk_officer_blocks_forward_motion_from_guardrail_sources(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Backtest review is BLOCKED. No out-of-sample evidence.",
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {
+            "skill": "data-quality-daily",
+            "status": "GREEN",
+            "owner_need": "none",
+            "brief": "Trading data quality is GREEN.",
+        },
+    )
+
+    response = answer_persona(
+        persona="risk",
+        message="Are you comfortable letting the strategy move forward, or are you objecting?",
+        root=tmp_path,
+    )
+
+    assert response["persona"] == "risk-officer"
+    assert response["owner_need"] == "none"
+    assert "I object" in response["answer"]
+    assert "I would not move it forward" in response["answer"]
+    assert "No out-of-sample evidence" in response["answer"]
+    assert "reports/skills/backtest-review/latest.json" in response["sources"]
+
+
+def test_growth_lead_refuses_to_invent_missing_analytics(tmp_path: Path) -> None:
+    response = answer_persona(
+        persona="growth",
+        message="What changed with the websites since yesterday?",
+        root=tmp_path,
+    )
+
+    assert response["persona"] == "growth-lead"
+    assert response["truth_state"] == "unknown"
+    assert "I do not have current growth evidence" in response["answer"]
+    assert response["sources"] == []
+
+
+def test_support_lead_reports_missing_inbox_source(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "support-triage" / "latest.json",
+        {
+            "skill": "support-triage",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Support triage is BLOCKED. No local support ticket source found.",
+        },
+    )
+
+    response = answer_persona(
+        persona="support",
+        message="Any angry customers or tickets I should know about?",
+        root=tmp_path,
+    )
+
+    assert response["persona"] == "support-lead"
+    assert "No local support ticket source found" in response["answer"]
+    assert response["truth_state"] == "known"

--- a/tests/test_persona_router.py
+++ b/tests/test_persona_router.py
@@ -474,6 +474,62 @@ def test_nanoclaw_live_returns_model_text_when_ollama_responds(monkeypatch) -> N
     assert captured["body"]["stream"] is False
 
 
+def test_answer_persona_uses_live_when_mode_live_and_falls_back_on_empty(monkeypatch, tmp_path: Path) -> None:
+    import urllib.request
+
+    import persona_verbalizer
+
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "Forecast attainment is RED.",
+        },
+    )
+
+    class _Resp:
+        def __init__(self, body): self._b = body
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self._b
+
+    def _ok(req, timeout=20):
+        return _Resp(json.dumps({"response": "Welcome back. Forecast attainment is RED and needs your call."}).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _ok)
+
+    conv = {"nanoclaw": {"mode": "shadow", "personas": {"chief-of-staff": "live"}}}
+    full = {"phase2": {"ollama_model": "llama3.2:latest", "ollama_base_url": "http://127.0.0.1:11434"}}
+
+    response = answer_persona(
+        persona="chief",
+        message="what needs me?",
+        root=tmp_path,
+        conversation_config=conv,
+        full_config=full,
+    )
+    assert response["verbalizer"]["provider"] == "nanoclaw_live"
+    assert response["no_model_calls"] is False
+    assert "Forecast attainment is RED" in response["answer"]
+
+    def _empty(req, timeout=20):
+        return _Resp(json.dumps({"response": ""}).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _empty)
+    response2 = answer_persona(
+        persona="chief",
+        message="what needs me?",
+        root=tmp_path,
+        conversation_config=conv,
+        full_config=full,
+    )
+    assert response2["verbalizer"]["provider"] == "deterministic_fallback"
+    assert response2["no_model_calls"] is True
+    assert "Forecast attainment is RED" in response2["answer"]
+
+
 def test_nanoclaw_live_returns_empty_answer_when_ollama_unreachable(monkeypatch) -> None:
     import urllib.error
     import urllib.request

--- a/tests/test_skill_backtest_review.py
+++ b/tests/test_skill_backtest_review.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from skill_backtest_review import run_backtest_review  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_backtest_review_blocks_current_weak_mt5_evidence(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "mt5-agentic-desk" / "logs" / "research" / "research_20260508_170002.json",
+        {
+            "summary": {
+                "selected_for_review": 8,
+                "approved": 0,
+                "rejected": 7,
+            },
+            "validation": {
+                "with_out_of_sample": 0,
+                "with_walk_forward": 0,
+            },
+            "review_results": [
+                {"decision": "APPROVE_BLOCKED"},
+                {"decision": "REJECT"},
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {"status": "GREEN", "brief": "Trading data quality is green."},
+    )
+
+    result = run_backtest_review(root=tmp_path)
+
+    assert result["ok"] is True
+    assert result["status"] == "BLOCKED"
+    assert result["autonomy"] == "Guardrail"
+    assert result["owner_need"] == "none"
+    assert result["metrics"]["approved_count"] == 0
+    assert result["metrics"]["pass_unchanged_rate_pct"] == 0.0
+    assert "approved 0" in result["brief"]
+    assert "out-of-sample" in result["brief"]
+    assert (tmp_path / result["markdown_path"]).exists()
+
+
+def test_run_backtest_review_requires_local_research_artifact(tmp_path: Path) -> None:
+    result = run_backtest_review(root=tmp_path)
+
+    assert result["status"] == "BLOCKED"
+    assert result["owner_need"] == "none"
+    assert "No MT5 research artifact found" in result["brief"]
+
+
+def test_run_backtest_review_can_pass_only_for_owner_approval(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "mt5-agentic-desk" / "logs" / "research" / "research_20260508_170002.json",
+        {
+            "summary": {
+                "selected_for_review": 4,
+                "approved": 1,
+                "rejected": 2,
+            },
+            "validation": {
+                "with_out_of_sample": 2,
+                "with_walk_forward": 1,
+            },
+            "review_results": [
+                {"decision": "APPROVE"},
+                {"decision": "REJECT"},
+                {"decision": "REJECT"},
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {"status": "GREEN", "brief": "Trading data quality is green."},
+    )
+
+    result = run_backtest_review(root=tmp_path)
+
+    assert result["status"] == "PASS_FOR_OWNER_APPROVAL"
+    assert result["owner_need"] == "approve"
+    assert result["metrics"]["pass_unchanged_rate_pct"] == 25.0
+    assert "cannot approve live or forward trading" in result["required_next_action"]

--- a/tests/test_skill_data_quality_daily.py
+++ b/tests/test_skill_data_quality_daily.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from skill_data_quality_daily import run_data_quality_daily  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_data_quality_daily_reports_green_for_current_mt5_evidence(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "mt5-agentic-desk" / "logs" / "evidence" / "daily_summary_2026-05-09.json",
+        {"date": "2026-05-09", "total_decisions": 3},
+    )
+
+    result = run_data_quality_daily(root=tmp_path, as_of=date(2026, 5, 9))
+
+    assert result["ok"] is True
+    assert result["status"] == "GREEN"
+    assert result["checks"][0]["name"] == "MT5 evidence freshness"
+    assert result["checks"][0]["status"] == "GREEN"
+    assert (tmp_path / result["markdown_path"]).exists()
+
+
+def test_run_data_quality_daily_blocks_when_mt5_evidence_missing(tmp_path: Path) -> None:
+    result = run_data_quality_daily(root=tmp_path, as_of=date(2026, 5, 9))
+
+    assert result["status"] == "BLOCKED"
+    assert result["owner_need"] == "none"
+    assert "No MT5 daily evidence summary found" in result["brief"]

--- a/tests/test_skill_portfolio_retro_weekly.py
+++ b/tests/test_skill_portfolio_retro_weekly.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from skill_portfolio_retro_weekly import run_portfolio_retro_weekly  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_portfolio_retro_weekly_blocks_without_skill_outputs(tmp_path: Path) -> None:
+    result = run_portfolio_retro_weekly(root=tmp_path)
+
+    assert result["ok"] is True
+    assert result["status"] == "BLOCKED"
+    assert result["owner_need"] == "none"
+    assert "No skill outputs found" in result["brief"]
+    assert (tmp_path / result["markdown_path"]).exists()
+
+
+def test_run_portfolio_retro_weekly_aggregates_skill_outputs_and_decisions(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "RED",
+            "owner_need": "approve",
+            "brief": "The company is RED.",
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Backtest review is BLOCKED.",
+        },
+    )
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {"approvals": [{"approval_id": "board_1"}]},
+            "decisions": {"board_old": {"decision": "APPROVED"}},
+        },
+    )
+
+    result = run_portfolio_retro_weekly(root=tmp_path)
+
+    assert result["status"] == "BLOCKED"
+    assert result["owner_need"] == "approve"
+    assert result["metrics"]["skill_outputs_count"] == 2
+    assert result["metrics"]["pending_approvals_count"] == 1
+    assert result["metrics"]["decisions_logged_count"] == 1
+    assert result["metrics"]["unresolved_issues_count"] == 2
+    assert result["open_issues"][0]["skill"] == "backtest-review"

--- a/tests/test_skill_risk_aggregate_daily.py
+++ b/tests/test_skill_risk_aggregate_daily.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from skill_risk_aggregate_daily import run_risk_aggregate_daily  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_risk_aggregate_daily_writes_natural_brief_and_sidecar(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "RED",
+                "risks": ["Forecast attainment is RED."],
+                "actions": ["Prioritize monetization levers."],
+            },
+        },
+    )
+    _write_json(
+        tmp_path / "state" / "board_approval_decisions.json",
+        {
+            "board_snapshot": {
+                "approvals": [
+                    {
+                        "approval_id": "board_forecast",
+                        "topic": "Company KPI: Forecast attainment",
+                        "decision": "Run monetization recovery.",
+                    }
+                ]
+            }
+        },
+    )
+
+    result = run_risk_aggregate_daily(root=tmp_path)
+
+    assert result["ok"] is True
+    assert result["status"] == "RED"
+    assert "You have one real decision today" in result["brief"]
+    assert result["owner_need"] == "approve"
+    markdown_path = tmp_path / result["markdown_path"]
+    json_path = tmp_path / result["json_path"]
+    assert markdown_path.exists()
+    assert json_path.exists()
+    assert "Forecast attainment is RED" in markdown_path.read_text(encoding="utf-8")
+    sidecar = json.loads(json_path.read_text(encoding="utf-8"))
+    assert sidecar["owner_need"] == "approve"
+    assert sidecar["sources"] == result["sources"]

--- a/tests/test_skill_support_triage.py
+++ b/tests/test_skill_support_triage.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from skill_support_triage import run_support_triage  # noqa: E402
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_support_triage_blocks_without_ticket_source(tmp_path: Path) -> None:
+    result = run_support_triage(root=tmp_path)
+
+    assert result["ok"] is True
+    assert result["status"] == "BLOCKED"
+    assert result["owner_need"] == "none"
+    assert "No local support ticket source found" in result["brief"]
+    assert (tmp_path / result["markdown_path"]).exists()
+
+
+def test_run_support_triage_classifies_tickets_without_exposing_email(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "state" / "support_tickets.json",
+        {
+            "tickets": [
+                {
+                    "id": "ticket_bug",
+                    "customer_email": "customer@example.com",
+                    "subject": "Calculator is broken",
+                    "body": "The position size calculator shows an error.",
+                },
+                {
+                    "id": "ticket_refund",
+                    "customer_email": "refund@example.com",
+                    "subject": "Refund request",
+                    "body": "I was charged and want a refund.",
+                },
+            ]
+        },
+    )
+
+    result = run_support_triage(root=tmp_path)
+
+    assert result["status"] == "AMBER"
+    assert result["owner_need"] == "approve"
+    assert result["metrics"]["ticket_count"] == 2
+    assert result["tickets"][0]["category"] == "bug"
+    assert result["tickets"][0]["draft_reply"]
+    assert result["tickets"][1]["category"] == "billing"
+    assert result["tickets"][1]["escalation_reason"] == "Billing, refund, legal, or account issue."
+    assert "customer@example.com" not in json.dumps(result)

--- a/tests/test_tool_router_ask_company.py
+++ b/tests/test_tool_router_ask_company.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_tool_router_ask_company_returns_truth_grounded_answer(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "AMBER",
+                "risks": ["Growth is below target."],
+                "actions": ["Review weekly analytics."],
+            },
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "ask_company",
+            "--question",
+            "What needs me today?",
+            "--root",
+            str(tmp_path),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert "company is AMBER" in payload["answer"]
+    assert "reports/phase3_holding_latest.json" in payload["sources"]
+
+
+def test_tool_router_ask_company_defaults_to_conversational_text(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "AMBER",
+                "risks": ["Growth is below target."],
+                "actions": ["Review weekly analytics."],
+            },
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "ask_company",
+            "--question",
+            "What needs me today?",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.startswith("You")
+    assert '"ok"' not in completed.stdout
+
+
+def test_tool_router_persona_chat_answers_free_text(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "backtest-review" / "latest.json",
+        {
+            "skill": "backtest-review",
+            "status": "BLOCKED",
+            "owner_need": "none",
+            "brief": "Backtest review is BLOCKED. No out-of-sample evidence.",
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "persona_chat",
+            "--persona",
+            "risk",
+            "--message",
+            "Can this strategy move forward?",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["persona"] == "risk-officer"
+    assert payload["no_model_calls"] is True
+    assert payload["truth_packet"]["policy"]["allowed_claim_source"] == "truth_packet_only"
+    assert payload["verbalizer"]["provider"] == "deterministic_fallback"
+    assert "I object" in payload["answer"]
+    assert "reports/skills/backtest-review/latest.json" in payload["sources"]
+
+
+def test_tool_router_nanoclaw_shadow_write_consumes_local_inbox(tmp_path: Path) -> None:
+    inbox_path = tmp_path / "state" / "nanoclaw_shadow_inbox.jsonl"
+    inbox_path.parent.mkdir(parents=True, exist_ok=True)
+    inbox_path.write_text(
+        json.dumps(
+            {
+                "type": "nanoclaw_shadow_request",
+                "packet_id": "packet_1",
+                "packet": {
+                    "packet_id": "packet_1",
+                    "persona": "chief-of-staff",
+                    "intent": "role",
+                    "evidence": [],
+                    "unknowns": [],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "nanoclaw_shadow_write",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["packet_id"] == "packet_1"
+    assert (tmp_path / "state" / "nanoclaw_shadow_outbox.jsonl").exists()
+
+
+def test_tool_router_risk_aggregate_daily_writes_skill_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "phase3_holding_latest.json",
+        {
+            "generated_at_utc": "2026-05-09T12:00:00+00:00",
+            "company_scorecard": {
+                "status": "GREEN",
+                "risks": [],
+                "actions": [],
+            },
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "risk_aggregate_daily",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["skill"] == "risk-aggregate-daily"
+    assert (tmp_path / payload["markdown_path"]).exists()
+
+
+def test_tool_router_data_quality_daily_writes_skill_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "mt5-agentic-desk" / "logs" / "evidence" / "daily_summary_2026-05-09.json",
+        {"date": "2026-05-09", "total_decisions": 3},
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "data_quality_daily",
+            "--root",
+            str(tmp_path),
+            "--as-of",
+            "2026-05-09",
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["skill"] == "data-quality-daily"
+    assert payload["status"] == "GREEN"
+    assert (tmp_path / payload["markdown_path"]).exists()
+
+
+def test_tool_router_backtest_review_writes_skill_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "mt5-agentic-desk" / "logs" / "research" / "research_20260508_170002.json",
+        {
+            "summary": {
+                "selected_for_review": 8,
+                "approved": 0,
+                "rejected": 7,
+            },
+            "validation": {
+                "with_out_of_sample": 0,
+                "with_walk_forward": 0,
+            },
+        },
+    )
+    _write_json(
+        tmp_path / "reports" / "skills" / "data-quality-daily" / "latest.json",
+        {"status": "GREEN", "brief": "Trading data quality is green."},
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "backtest_review",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["skill"] == "backtest-review"
+    assert payload["status"] == "BLOCKED"
+    assert (tmp_path / payload["markdown_path"]).exists()
+
+
+def test_tool_router_support_triage_writes_skill_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "state" / "support_tickets.json",
+        {
+            "tickets": [
+                {
+                    "id": "ticket_feature",
+                    "subject": "Feature request",
+                    "body": "Can you add MyForexFunds rules?",
+                }
+            ]
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "support_triage",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["skill"] == "support-triage"
+    assert payload["status"] == "AMBER"
+    assert (tmp_path / payload["markdown_path"]).exists()
+
+
+def test_tool_router_portfolio_retro_weekly_writes_skill_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "reports" / "skills" / "risk-aggregate-daily" / "latest.json",
+        {
+            "skill": "risk-aggregate-daily",
+            "status": "GREEN",
+            "owner_need": "none",
+            "brief": "Company is green.",
+        },
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tool_router.py",
+            "portfolio_retro_weekly",
+            "--root",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["skill"] == "portfolio-retro-weekly"
+    assert payload["status"] == "GREEN"
+    assert (tmp_path / payload["markdown_path"]).exists()

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -166,6 +166,7 @@ def test_markdown_review_scanner_creates_idempotent_work_items(tmp_path: Path) -
         assert second == {"ok": True, "created": 0, "existing": 1}
         assert status["counts"]["pending_approval"] == 1
         assert status["decide"][0]["source"] == "markdown:finance_web_page/STAGE_L_L2.9_CLOSURE.md"
+        assert status["decide"][0]["metadata"]["executor"] == "review_markdown_artifact"
     finally:
         conn.close()
 
@@ -267,5 +268,82 @@ def test_run_next_executes_ledger_status_snapshot(tmp_path: Path) -> None:
         assert result["item"]["status"] == "DONE"
         assert result["item"]["result"] == "Ledger status snapshot generated."
         assert "Work Ledger" in result["item"]["evidence"][0]["summary"]
+    finally:
+        conn.close()
+
+
+def test_run_next_executes_scanned_review_markdown(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        closure = tmp_path / "finance_web_page" / "STAGE_L_L2.9_CLOSURE.md"
+        closure.parent.mkdir()
+        closure.write_text(
+            "\n".join(
+                [
+                    "# Stage L L2.9 Closure",
+                    "",
+                    "**Status:** READY FOR MA REVIEW - 2026-05-08",
+                    "",
+                    "- [x] Tests passed",
+                    "- [ ] CEO sign-off recorded",
+                    "",
+                    "Risk review: no production credentials touched.",
+                    "Evidence: reports/stage-l.md",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        scan_ready_for_review_markdown(conn, root=tmp_path)
+        pending = work_status(conn)["decide"][0]
+        approve_work_item(
+            conn,
+            pending["id"],
+            owner="MA",
+            due_at="2026-05-08T18:00:00+00:00",
+            completion_signal="Review summary evidence exists.",
+        )
+
+        result = run_next_work_item(conn)
+
+        assert result["ran"] is True
+        assert result["outcome"] == "done"
+        assert result["executor"] == "review_markdown_artifact"
+        assert result["item"]["status"] == "DONE"
+        evidence = result["item"]["evidence"][0]["summary"]
+        assert "Review artifact summarized: STAGE_L_L2.9_CLOSURE.md" in evidence
+        assert "Heading: Stage L L2.9 Closure" in evidence
+        assert "Checklist: 1 checked, 1 open" in evidence
+        assert "Risk review: no production credentials touched." in evidence
+    finally:
+        conn.close()
+
+
+def test_run_next_blocks_scanned_review_when_file_is_missing(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(
+            conn,
+            title="Missing review artifact",
+            work_type="review",
+            source="markdown:missing.md",
+            metadata={
+                "executor": "review_markdown_artifact",
+                "path": "missing.md",
+                "scan_root": str(tmp_path),
+            },
+        )
+        approve_work_item(
+            conn,
+            item["id"],
+            owner="MA",
+            due_at="2026-05-08T18:00:00+00:00",
+            completion_signal="Review summary evidence exists.",
+        )
+
+        result = run_next_work_item(conn)
+
+        assert result["outcome"] == "blocked"
+        assert "path is missing" in result["reason"]
+        assert result["item"]["status"] == "BLOCKED"
     finally:
         conn.close()

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kernel.db import connect
+from kernel.views import render_status_text, work_status
+from kernel.work_items import (
+    approve_work_item,
+    create_work_item,
+    done_work_item,
+    scan_ready_for_review_markdown,
+    start_work_item,
+)
+
+
+def _conn(tmp_path: Path):
+    return connect(tmp_path / "work_ledger.db")
+
+
+def test_ready_for_review_item_appears_in_decision_queue(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, created = create_work_item(
+            conn,
+            title="Review Stage L closure",
+            work_type="review",
+            source="markdown:stage.md",
+            status="READY_FOR_REVIEW",
+            owner="CEO",
+            needs_approval=True,
+        )
+
+        status = work_status(conn)
+
+        assert created is True
+        assert item["approval_status"] == "PENDING"
+        assert status["counts"]["pending_approval"] == 1
+        assert status["decide"][0]["title"] == "Review Stage L closure"
+    finally:
+        conn.close()
+
+
+def test_approval_requires_owner_due_date_and_completion_signal(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(
+            conn,
+            title="Metric refresh",
+            work_type="task",
+            source="manual",
+            needs_approval=True,
+        )
+
+        with pytest.raises(ValueError, match="owner, due_at, and completion_signal"):
+            approve_work_item(
+                conn,
+                item["id"],
+                owner="Commercial",
+                due_at="",
+                completion_signal="Updated metric source.",
+            )
+
+        approved = approve_work_item(
+            conn,
+            item["id"],
+            owner="Commercial",
+            due_at="2026-05-08T18:00:00+00:00",
+            completion_signal="Updated metric source.",
+        )
+
+        assert approved["status"] == "APPROVED"
+        assert approved["owner"] == "Commercial"
+        assert approved["due_at"] == "2026-05-08T18:00:00+00:00"
+        assert approved["completion_signal"] == "Updated metric source."
+    finally:
+        conn.close()
+
+
+def test_approved_and_started_items_appear_in_execution_queue(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(conn, title="Prepare FTMO draft", work_type="task", source="manual")
+        approve_work_item(
+            conn,
+            item["id"],
+            owner="Marketing",
+            due_at="2026-05-08T20:00:00+00:00",
+            completion_signal="Draft exists without publication.",
+        )
+
+        status = work_status(conn)
+        assert status["counts"]["approved"] == 1
+        assert status["execute"][0]["owner"] == "Marketing"
+
+        start_work_item(conn, item["id"])
+        started_status = work_status(conn)
+        assert started_status["counts"]["in_progress"] == 1
+        assert started_status["execute"][0]["status"] == "IN_PROGRESS"
+    finally:
+        conn.close()
+
+
+def test_overdue_item_is_visible_in_status_text(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(conn, title="Overdue work", work_type="task", source="manual")
+        approve_work_item(
+            conn,
+            item["id"],
+            owner="Holding",
+            due_at="2026-05-01T12:00:00+00:00",
+            completion_signal="Heartbeat rerun.",
+        )
+
+        status = work_status(conn, now=datetime(2026, 5, 8, tzinfo=timezone.utc))
+        text = render_status_text(status)
+
+        assert status["counts"]["overdue"] == 1
+        assert "Overdue work" in text
+        assert "Overdue" in text
+    finally:
+        conn.close()
+
+
+def test_done_requires_result_and_evidence(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(conn, title="Close with proof", work_type="task", source="manual")
+
+        with pytest.raises(ValueError, match="result and evidence"):
+            done_work_item(conn, item["id"], result="Complete", evidence="")
+
+        done = done_work_item(
+            conn,
+            item["id"],
+            result="Complete",
+            evidence="reports/example.md confirms completion.",
+        )
+
+        assert done["status"] == "DONE"
+        assert done["result"] == "Complete"
+        assert done["evidence"][0]["summary"] == "reports/example.md confirms completion."
+    finally:
+        conn.close()
+
+
+def test_markdown_review_scanner_creates_idempotent_work_items(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        closure = tmp_path / "finance_web_page" / "STAGE_L_L2.9_CLOSURE.md"
+        closure.parent.mkdir()
+        closure.write_text(
+            "# Closure\n\n**Status:** READY FOR MA REVIEW - 2026-05-08\n",
+            encoding="utf-8",
+        )
+
+        first = scan_ready_for_review_markdown(conn, root=tmp_path)
+        second = scan_ready_for_review_markdown(conn, root=tmp_path)
+        status = work_status(conn)
+
+        assert first == {"ok": True, "created": 1, "existing": 0}
+        assert second == {"ok": True, "created": 0, "existing": 1}
+        assert status["counts"]["pending_approval"] == 1
+        assert status["decide"][0]["source"] == "markdown:finance_web_page/STAGE_L_L2.9_CLOSURE.md"
+    finally:
+        conn.close()

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from kernel.db import connect
-from kernel.views import render_status_text, work_status
+from kernel.views import render_reminder_text, render_status_text, work_reminders, work_status
 from kernel.work_items import (
     approve_work_item,
     create_work_item,
@@ -165,5 +165,38 @@ def test_markdown_review_scanner_creates_idempotent_work_items(tmp_path: Path) -
         assert second == {"ok": True, "created": 0, "existing": 1}
         assert status["counts"]["pending_approval"] == 1
         assert status["decide"][0]["source"] == "markdown:finance_web_page/STAGE_L_L2.9_CLOSURE.md"
+    finally:
+        conn.close()
+
+
+def test_work_reminders_include_owner_action_items_once(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        review, _ = create_work_item(
+            conn,
+            title="Review Stage L closure",
+            work_type="review",
+            source="markdown:stage.md",
+            status="READY_FOR_REVIEW",
+            owner="CEO",
+            needs_approval=True,
+        )
+        overdue, _ = create_work_item(conn, title="Overdue owner task", work_type="task", source="manual")
+        approve_work_item(
+            conn,
+            overdue["id"],
+            owner="CEO",
+            due_at="2026-05-01T12:00:00+00:00",
+            completion_signal="Decision recorded.",
+        )
+
+        reminders = work_reminders(conn, now=datetime(2026, 5, 8, tzinfo=timezone.utc))
+        text = render_reminder_text(reminders)
+
+        assert reminders["needs_attention"] is True
+        assert reminders["count"] == 2
+        assert {item["id"] for item in reminders["items"]} == {review["id"], overdue["id"]}
+        assert "Needs approval" in text
+        assert "Overdue" in text
     finally:
         conn.close()

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -7,6 +7,7 @@ import pytest
 
 from kernel.db import connect
 from kernel.views import render_reminder_text, render_status_text, work_reminders, work_status
+from kernel.worker import run_next_work_item
 from kernel.work_items import (
     approve_work_item,
     create_work_item,
@@ -198,5 +199,73 @@ def test_work_reminders_include_owner_action_items_once(tmp_path: Path) -> None:
         assert {item["id"] for item in reminders["items"]} == {review["id"], overdue["id"]}
         assert "Needs approval" in text
         assert "Overdue" in text
+    finally:
+        conn.close()
+
+
+def test_run_next_reports_no_approved_work(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        result = run_next_work_item(conn)
+
+        assert result == {
+            "ok": True,
+            "ran": False,
+            "message": "No approved work items are ready to run.",
+            "item": None,
+        }
+    finally:
+        conn.close()
+
+
+def test_run_next_blocks_when_no_executor_exists(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(conn, title="Manual review", work_type="review", source="manual")
+        approve_work_item(
+            conn,
+            item["id"],
+            owner="MA",
+            due_at="2026-05-08T18:00:00+00:00",
+            completion_signal="Review note exists.",
+        )
+
+        result = run_next_work_item(conn)
+        status = work_status(conn)
+
+        assert result["ran"] is True
+        assert result["outcome"] == "blocked"
+        assert result["item"]["status"] == "BLOCKED"
+        assert "No automated executor is registered" in result["reason"]
+        assert status["counts"]["blocked"] == 1
+    finally:
+        conn.close()
+
+
+def test_run_next_executes_ledger_status_snapshot(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    try:
+        item, _ = create_work_item(
+            conn,
+            title="Generate ledger snapshot",
+            work_type="ledger_report",
+            source="manual",
+            metadata={"executor": "ledger_status_snapshot"},
+        )
+        approve_work_item(
+            conn,
+            item["id"],
+            owner="System",
+            due_at="2026-05-08T18:00:00+00:00",
+            completion_signal="Ledger status snapshot evidence exists.",
+        )
+
+        result = run_next_work_item(conn)
+
+        assert result["ran"] is True
+        assert result["outcome"] == "done"
+        assert result["item"]["status"] == "DONE"
+        assert result["item"]["result"] == "Ledger status snapshot generated."
+        assert "Work Ledger" in result["item"]["evidence"][0]["summary"]
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

Brings the persona conversational layer from shadow-only/deterministic to production-ready Ollama-backed live answers, gated by an explicit acceptance ratchet. Live model output never reaches the owner unless `verify_verbalizer_output()` accepts it; on any failure the deterministic fallback answers. Per-persona config flag controls promotion — no auto-promotion.

R1 (Ollama only) preserved. No new dependencies. Stdlib `urllib` only.

## Commits (4 NanoClaw steps + handoff)

| Commit | Step | What |
|---|---|---|
| `1d8d3e1` | 0 | Chief of Staff drops "I would focus there first" when lead evidence is GREEN |
| `66dfc08` | 1 | `nanoclaw_live_verbalize()` — local Ollama `/api/generate`, 20s timeout, empty-on-failure |
| `349ecce` | 2 | `run_verbalizers` gates live mode per persona, verifies, falls back to deterministic on any rejection |
| `63319e2` | 3 | `conversation.nanoclaw.promotion` + `personas` config, live decision log, `nanoclaw_status` CLI |
| `66cccdf` | docs | `HANDOFF_NANOCLAW.md` for dispatch continuation |

## What ships in this PR

- **Live provider** (`scripts/persona_verbalizer.py:nanoclaw_live_verbalize`) — POSTs the sealed truth packet to `{phase2.ollama_base_url}/api/generate` with `{phase2.ollama_model}`. No retries, no streaming, single hard timeout.
- **Per-persona gate** (`scripts/persona_verbalizer.py:_effective_nanoclaw_mode`) — `conversation.nanoclaw.personas[<persona>]` beats global `conversation.nanoclaw.mode`. Default is `shadow` for all 8 personas.
- **Verifier fallback** — every live answer goes through `verify_verbalizer_output()`. Rejected output is replaced with the deterministic answer (tagged with `nanoclaw_live_rejected_reason`).
- **Acceptance ratchet** — `state/nanoclaw_live_log.jsonl` records every live attempt (accepted/rejected/reason). `python scripts/tool_router.py nanoclaw_status` aggregates the last `window` records per persona and reports `meets_gate` (default `window=50, min_accept_rate=0.80`).
- **GREEN polish** — Chief of Staff's `_chief_status()` no longer prefixes GREEN-lead evidence with urgency framing.

## Tests

28 passing (was 21). Added:
- `test_chief_of_staff_green_state_drops_urgency_framing`
- `test_nanoclaw_live_returns_model_text_when_ollama_responds` (urlopen mocked)
- `test_nanoclaw_live_returns_empty_answer_when_ollama_unreachable`
- `test_answer_persona_uses_live_when_mode_live_and_falls_back_on_empty`
- `tests/test_nanoclaw_status.py` (3 tests)

## Test plan

- [ ] `python -m pytest tests/test_persona_router.py tests/test_tool_router_ask_company.py tests/test_nanoclaw_status.py -q` → 28 passed
- [ ] `python scripts/tool_router.py nanoclaw_status` → returns JSON with all 8 personas at `current_mode: shadow`, zero log entries
- [ ] Verify `curl -s http://127.0.0.1:11434/api/tags` works on the host that runs the bridge before any persona is flipped to `live`
- [ ] Flip `conversation.nanoclaw.personas.chief-of-staff: "live"` only after dispatch reviews Step 7 verifier hardening in `HANDOFF_NANOCLAW.md`

## Non-goals (deliberate)

- No new persona surface (still 8).
- No streaming, no multi-turn memory, no tool-use from the model.
- No provider abstraction layer — one provider (Ollama), one HTTP call.
- No auto-promotion. Owner reads `nanoclaw_status`, owner edits YAML.

## Reviewer pointers

- Full system overview: `NANOCLAW_TEST_REPORT.md`
- Dispatch continuation plan (Steps 4-8): `HANDOFF_NANOCLAW.md`
- Constraints honored: R1 (Ollama only), R11 (Telegram bridge sole automation), `shell=False`, no overengineering.